### PR TITLE
Avoid blacklist on timeout exception reading packet

### DIFF
--- a/src/main/java/jones/sonar/universal/util/ExceptionHandler.java
+++ b/src/main/java/jones/sonar/universal/util/ExceptionHandler.java
@@ -1,6 +1,7 @@
 package jones.sonar.universal.util;
 
 import io.netty.channel.Channel;
+import io.netty.handler.timeout.ReadTimeoutException;
 import jones.sonar.universal.blacklist.Blacklist;
 import jones.sonar.universal.data.ServerStatistics;
 import lombok.experimental.UtilityClass;
@@ -19,7 +20,7 @@ public class ExceptionHandler {
 
         // IOException can be thrown by disconnecting from the server
         // We need to exempt clients for that, so they won't get false blacklisted
-        if (cause instanceof IOException) return;
+        if (cause instanceof IOException && ReadTimeoutException) return;
         /*
         System.out.println("===========================================================");
         System.out.println(channel.remoteAddress() + " has thrown: " + cause);

--- a/src/main/java/jones/sonar/universal/util/ExceptionHandler.java
+++ b/src/main/java/jones/sonar/universal/util/ExceptionHandler.java
@@ -20,7 +20,7 @@ public class ExceptionHandler {
 
         // IOException can be thrown by disconnecting from the server
         // We need to exempt clients for that, so they won't get false blacklisted
-        if (cause instanceof IOException && ReadTimeoutException) return;
+        if (cause instanceof IOException || cause instanceof ReadTimeoutException) return;
         /*
         System.out.println("===========================================================");
         System.out.println(channel.remoteAddress() + " has thrown: " + cause);


### PR DESCRIPTION
A client can for any reason (usually lag) throw a timeout in the login process making the connection blacklisted.

Even when some mod is not supported by bungeecord usually throws a timeout by the incapacity of reading that forge data
Or also if the connection stops sending keepalive data it will throw the same exception and disconnect it, after that will be blacklisted.