### PR TITLE
Implement unofficial branch warnings and improve version management

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,7 +17,7 @@ val semanticVersion = "2.0.0"
 
 versioner {
   pattern {
-    pattern = "$semanticVersion-%h(-%c)"
+    pattern = "$semanticVersion-%h-%c-%b"
   }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -12,12 +12,9 @@ plugins {
 
 apply(plugin = "io.toolebox.git-versioner")
 
-rootProject.group = "xyz.jonesdev.sonar"
-val semanticVersion = "2.0.0"
-
 versioner {
   pattern {
-    pattern = "$semanticVersion-%h-%c-%b"
+    pattern = "$version-%h-%c-%b"
   }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -62,6 +62,7 @@ tasks {
       // Set the implementation version, so we can create exact version
       // information in-game and make it accessible to the user.
       attributes["Implementation-Version"] = version
+      attributes["Implementation-Vendor"] = "Jones Development, Sonar Contributors"
     }
   }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,0 +1,2 @@
+group=xyz.jonesdev.sonar
+version=2.0.0

--- a/sonar-api/src/main/java/xyz/jonesdev/sonar/api/SonarVersion.java
+++ b/sonar-api/src/main/java/xyz/jonesdev/sonar/api/SonarVersion.java
@@ -24,6 +24,7 @@ public final class SonarVersion {
   static final SonarVersion GET = new SonarVersion();
   private final String semanticVersion, full, formatted, commitSHA;
   private final int build;
+  private final boolean isOnMainBranch;
 
   SonarVersion() {
     final Package manifest = Sonar.class.getPackage();
@@ -31,11 +32,12 @@ public final class SonarVersion {
 
     if (versionString == null) {
       this.full = "<could not retrieve version>";
-      this.semanticVersion = "<unknown>";
-      this.commitSHA = "<unknown>";
-      this.build = 0;
+      this.semanticVersion = "<unknown version>";
+      this.commitSHA = "<unknown commit>";
+      this.build = -1;
+      this.isOnMainBranch = false;
       this.formatted = full;
-      Sonar.get().getLogger().error("Could not find version information (Is the manifest missing?)");
+      Sonar.get().getLogger().warn("Could not find version information. Is the manifest missing?");
       return;
     }
 
@@ -43,6 +45,7 @@ public final class SonarVersion {
     this.semanticVersion = versionString.split("-")[0];
     this.commitSHA = versionString.split("-")[1];
     this.build = Integer.parseInt(versionString.split("-")[2]);
+    this.isOnMainBranch = versionString.split("-")[3].equals("main");
     this.formatted = semanticVersion + " build " + build + " (" + commitSHA + ")";
   }
 

--- a/sonar-bukkit/build.gradle.kts
+++ b/sonar-bukkit/build.gradle.kts
@@ -8,7 +8,7 @@ apply(plugin = "net.minecrell.plugin-yml.bukkit")
 
 bukkit {
   name = rootProject.name
-  version = rootProject.version.toString()
+  version = rootProject.version.toString().split("-")[0]
   main = "xyz.jonesdev.sonar.bukkit.SonarBukkitPlugin"
   authors = listOf("Jones Development", "Sonar Contributors")
   website = "https://jonesdev.xyz/discord/"

--- a/sonar-bungee/build.gradle.kts
+++ b/sonar-bungee/build.gradle.kts
@@ -6,7 +6,7 @@ apply(plugin = "net.minecrell.plugin-yml.bungee")
 
 bungee {
   name = rootProject.name
-  version = rootProject.version.toString()
+  version = rootProject.version.toString().split("-")[0]
   main = "xyz.jonesdev.sonar.bukkit.SonarBukkitPlugin"
   author = "Jones Development, Sonar Contributors"
   description = "Effective Anti-bot plugin for Velocity, BungeeCord, and Bukkit (1.7-latest)"

--- a/sonar-common/src/main/java/xyz/jonesdev/sonar/common/boot/SonarBootstrap.java
+++ b/sonar-common/src/main/java/xyz/jonesdev/sonar/common/boot/SonarBootstrap.java
@@ -63,6 +63,13 @@ public abstract class SonarBootstrap<T> implements Sonar {
   }
 
   public final void initialize() {
+    // Check if the branch is not the main branch to warn about unstable versions
+    if (!getVersion().isOnMainBranch()) {
+      getLogger().warn("You are currently using an unofficial experimental branch.");
+      getLogger().warn("It is highly recommended to use the latest stable release of Sonar:");
+      getLogger().warn("https://github.com/jonesdevelopment/sonar/releases");
+    }
+
     getLogger().info("Successfully booted in {}s!", launchTimer);
     getLogger().info("Initializing shared components...");
 


### PR DESCRIPTION
Using an unofficial branch (e.g. a custom built jar) will now result in this warning:
![image](https://github.com/jonesdevelopment/sonar/assets/73846784/85159d76-24bf-48a4-b609-744d3d5ac6df)
This does not affect the initial plugin launch in any way.