### PR TITLE
Bump dependencies

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -47,7 +47,7 @@ subprojects {
     implementation("com.j256.ormlite:ormlite-jdbc:6.1") // ORM
     implementation("xyz.jonesdev:cappuccino:0.1.6-SNAPSHOT") // expiring cache
 
-    compileOnly("io.netty:netty-all:4.1.98.Final") // netty
+    compileOnly("io.netty:netty-all:4.1.99.Final") // netty
   }
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
- Bump netty from 4.1.98 to 4.1.99
- Bump gradle from 8.2 to 8.3