### PR TITLE
Rename MySQL table to avoid naming collisions

### DIFF
--- a/sonar-api/src/main/java/xyz/jonesdev/sonar/api/dependencies/DependencyLoader.java
+++ b/sonar-api/src/main/java/xyz/jonesdev/sonar/api/dependencies/DependencyLoader.java
@@ -72,9 +72,7 @@ public class DependencyLoader {
 
     final Properties properties = new Properties();
     properties.put("user", database.getUsername());
-    if (!database.getPassword().isEmpty()) {
-      properties.put("password", database.getPassword());
-    }
+    properties.put("password", database.getPassword());
 
     final Method connect = driverClass.getDeclaredMethod("connect", String.class, Properties.class);
     connect.setAccessible(true);

--- a/sonar-api/src/main/java/xyz/jonesdev/sonar/api/model/VerifiedPlayer.java
+++ b/sonar-api/src/main/java/xyz/jonesdev/sonar/api/model/VerifiedPlayer.java
@@ -29,7 +29,7 @@ import java.util.UUID;
 @Getter
 @ToString
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@DatabaseTable(tableName = "verified_players")
+@DatabaseTable(tableName = "sonar_verified_players")
 public final class VerifiedPlayer {
   @SuppressWarnings("unused")
   @DatabaseField(generatedId = true)
@@ -51,7 +51,10 @@ public final class VerifiedPlayer {
   )
   private UUID playerUUID;
 
-  @DatabaseField(columnName = "timestamp", canBeNull = false)
+  @DatabaseField(
+    columnName = "timestamp",
+    canBeNull = false
+  )
   private long timestamp;
 
   public VerifiedPlayer(final String inetAddress, final UUID playerUUID, final long timestamp) {

--- a/sonar-api/src/main/java/xyz/jonesdev/sonar/api/model/VerifiedPlayer.java
+++ b/sonar-api/src/main/java/xyz/jonesdev/sonar/api/model/VerifiedPlayer.java
@@ -24,6 +24,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 
+import java.sql.Timestamp;
 import java.util.UUID;
 
 @Getter
@@ -55,11 +56,11 @@ public final class VerifiedPlayer {
     columnName = "timestamp",
     canBeNull = false
   )
-  private long timestamp;
+  private Timestamp timestamp;
 
   public VerifiedPlayer(final String inetAddress, final UUID playerUUID, final long timestamp) {
     this.inetAddress = inetAddress;
     this.playerUUID = playerUUID;
-    this.timestamp = timestamp;
+    this.timestamp = new Timestamp(timestamp);
   }
 }


### PR DESCRIPTION
```
mysql> show tables;
+------------------------------------+
| Tables_in_minecraft                |
+------------------------------------+
| luckperms_actions                  |
| luckperms_group_permissions        |
| luckperms_groups                   |
| luckperms_messenger                |
| luckperms_players                  |
| luckperms_tracks                   |
| luckperms_user_permissions         |
| verified_players                   |                    < issue
+------------------------------------+
```