### PR TITLE
Optimize verification by using different data types

### DIFF
--- a/sonar-api/src/main/java/xyz/jonesdev/sonar/api/config/SonarConfiguration.java
+++ b/sonar-api/src/main/java/xyz/jonesdev/sonar/api/config/SonarConfiguration.java
@@ -489,12 +489,12 @@ public final class SonarConfiguration {
       + LINE_SEPARATOR + "https://wiki.vg/Protocol_version_numbers"
       + LINE_SEPARATOR + "For example, Minecraft 1.20 has the ID 763.");
     verification.whitelistedProtocols.clear();
-    verification.whitelistedProtocols.addAll(generalConfig.getIntList("verification.whitelisted-protocols", Collections.emptyList()));
+    verification.whitelistedProtocols.addAll(generalConfig.getIntList("verification.whitelisted-protocols", new ArrayList<>(0)));
 
     generalConfig.getYaml().setComment("verification.blacklisted-protocols",
       "List of protocol IDs which are unable to join the server at all");
     verification.blacklistedProtocols.clear();
-    verification.blacklistedProtocols.addAll(generalConfig.getIntList("verification.blacklisted-protocols", Collections.emptyList()));
+    verification.blacklistedProtocols.addAll(generalConfig.getIntList("verification.blacklisted-protocols", new ArrayList<>(0)));
 
     generalConfig.getYaml().setComment("webhook",
       "Bot attack notifications can also be sent to your Discord server using webhooks");

--- a/sonar-api/src/main/java/xyz/jonesdev/sonar/api/config/SonarConfiguration.java
+++ b/sonar-api/src/main/java/xyz/jonesdev/sonar/api/config/SonarConfiguration.java
@@ -135,8 +135,8 @@ public final class SonarConfiguration {
     private int maxPing;
     private int readTimeout;
     private int reconnectDelay;
-    private final Collection<Integer> whitelistedProtocols = new Vector<>(0);
-    private final Collection<Integer> blacklistedProtocols = new Vector<>(0);
+    private final Collection<Integer> whitelistedProtocols = new HashSet<>(0);
+    private final Collection<Integer> blacklistedProtocols = new HashSet<>(0);
 
     private Component tooManyPlayers;
     private Component tooFastReconnect;

--- a/sonar-api/src/main/java/xyz/jonesdev/sonar/api/config/SonarConfiguration.java
+++ b/sonar-api/src/main/java/xyz/jonesdev/sonar/api/config/SonarConfiguration.java
@@ -131,7 +131,6 @@ public final class SonarConfiguration {
     private int maxBrandLength;
     private int maxMovementTicks;
     private int maxIgnoredTicks;
-    private int maxVerifyingPlayers;
     private int maxLoginPackets;
     private int maxPing;
     private int readTimeout;
@@ -479,11 +478,6 @@ public final class SonarConfiguration {
     generalConfig.getYaml().setComment("verification.read-timeout",
       "Amount of time that has to pass before a player times out");
     verification.readTimeout = clamp(generalConfig.getInt("verification.read-timeout", 3500), 500, 30000);
-
-    generalConfig.getYaml().setComment("verification.max-players",
-      "Maximum number of players verifying at the same time");
-    verification.maxVerifyingPlayers = clamp(generalConfig.getInt("verification.max-players", 1024), 1,
-      Short.MAX_VALUE);
 
     generalConfig.getYaml().setComment("verification.rejoin-delay",
       "Minimum number of rejoin delay during verification");

--- a/sonar-api/src/main/java/xyz/jonesdev/sonar/api/fallback/Fallback.java
+++ b/sonar-api/src/main/java/xyz/jonesdev/sonar/api/fallback/Fallback.java
@@ -40,11 +40,10 @@ public final class Fallback {
   public static final Fallback INSTANCE = new Fallback();
   private static final @NotNull Sonar SONAR = Objects.requireNonNull(Sonar.get());
 
-  private final Map<String, InetAddress> connected = new ConcurrentHashMap<>();
+  private final Map<String, InetAddress> connected = new ConcurrentHashMap<>(64, 0.75f);
   // Only block the player for a few minutes to avoid issues
   private final ExpiringCache<InetAddress> blacklisted = Cappuccino.buildExpiring(
-    10L, TimeUnit.MINUTES, 5000L
-  );
+    10L, TimeUnit.MINUTES, 5000L);
   private final @NotNull FallbackQueue queue = FallbackQueue.INSTANCE;
   private final @NotNull FallbackRatelimiter ratelimiter = FallbackRatelimiter.INSTANCE;
 

--- a/sonar-bungee/src/main/java/xyz/jonesdev/sonar/bungee/fallback/FallbackInitialHandler.java
+++ b/sonar-bungee/src/main/java/xyz/jonesdev/sonar/bungee/fallback/FallbackInitialHandler.java
@@ -215,13 +215,6 @@ public final class FallbackInitialHandler extends InitialHandler {
           return;
         }
 
-        // We cannot allow too many players on our Fallback server
-        // There's technically no reason for limiting this, but we'll better stay safe.
-        if (FALLBACK.getConnected().size() > Sonar.get().getConfig().getVerification().getMaxVerifyingPlayers()) {
-          closeWith(getKickPacket(Sonar.get().getConfig().getVerification().getTooManyPlayers()));
-          return;
-        }
-
         // Check if the IP address is currently being rate-limited
         if (!FALLBACK.getRatelimiter().attempt(inetAddress)) {
           closeWith(getKickPacket(Sonar.get().getConfig().getVerification().getTooFastReconnect()));

--- a/sonar-velocity/src/main/java/xyz/jonesdev/sonar/velocity/fallback/FallbackListener.java
+++ b/sonar-velocity/src/main/java/xyz/jonesdev/sonar/velocity/fallback/FallbackListener.java
@@ -220,16 +220,6 @@ public final class FallbackListener {
           return;
         }
 
-        // We cannot allow too many players on our Fallback server
-        // There's technically no reason for limiting this, but we'll better stay safe.
-        if (fallback.getConnected().size() > Sonar.get().getConfig().getVerification().getMaxVerifyingPlayers()) {
-          initialConnection.getConnection().closeWith(Disconnect.create(
-            Sonar.get().getConfig().getVerification().getTooManyPlayers(),
-            inboundConnection.getProtocolVersion()
-          ));
-          return;
-        }
-
         // Check if the IP address is currently being rate-limited
         if (!fallback.getRatelimiter().attempt(inetAddress)) {
           initialConnection.getConnection().closeWith(Disconnect.create(


### PR DESCRIPTION
- Switch to HashSet for storing whitelist and blacklisted protocol IDs
- Remove `max-verifying-players` option from the configuration
- Fixes an issue with SnakeYAML's formatter