### PR TITLE
Fix Chat packet using the wrong packet id in 1.20.2

### DIFF
--- a/sonar-common/src/main/java/xyz/jonesdev/sonar/common/fallback/protocol/FallbackPacketRegistry.java
+++ b/sonar-common/src/main/java/xyz/jonesdev/sonar/common/fallback/protocol/FallbackPacketRegistry.java
@@ -235,7 +235,7 @@ public enum FallbackPacketRegistry {
         map(0x60, MINECRAFT_1_19_3, false),
         map(0x64, MINECRAFT_1_19_4, false),
         map(0x67, MINECRAFT_1_20_2, false),
-        map(0x69, MINECRAFT_1_20_2, false));
+        map(0x69, MINECRAFT_1_20_3, false));
       clientbound.register(GameEvent.class, GameEvent::new,
         map(0x20, MINECRAFT_1_20_3, true));
 


### PR DESCRIPTION
- Resolves issues with 1.20.2 clients — other versions are not affected