### PR TITLE
Fix event priorities for some event listeners

### DIFF
--- a/sonar-bukkit/src/main/java/xyz/jonesdev/sonar/bukkit/audience/AudienceListener.java
+++ b/sonar-bukkit/src/main/java/xyz/jonesdev/sonar/bukkit/audience/AudienceListener.java
@@ -29,13 +29,13 @@ import xyz.jonesdev.sonar.bukkit.SonarBukkit;
 
 public final class AudienceListener implements Listener {
 
-  @EventHandler(priority = EventPriority.LOWEST)
+  @EventHandler(priority = EventPriority.HIGHEST)
   public void handle(final @NotNull PlayerJoinEvent event) {
     final Audience audience = SonarBukkit.INSTANCE.getBukkitAudiences().player(event.getPlayer());
     Sonar.get().getVerboseHandler().getAudiences().put(event.getPlayer().getName(), audience);
   }
 
-  @EventHandler(priority = EventPriority.LOWEST)
+  @EventHandler(priority = EventPriority.HIGHEST)
   public void handle(final @NotNull PlayerQuitEvent event) {
     Sonar.get().getVerboseHandler().getAudiences().remove(event.getPlayer().getName());
   }

--- a/sonar-bungee/src/main/java/xyz/jonesdev/sonar/bungee/audience/AudienceListener.java
+++ b/sonar-bungee/src/main/java/xyz/jonesdev/sonar/bungee/audience/AudienceListener.java
@@ -29,13 +29,13 @@ import xyz.jonesdev.sonar.bungee.SonarBungee;
 
 public final class AudienceListener implements Listener {
 
-  @EventHandler(priority = EventPriority.LOWEST)
+  @EventHandler(priority = EventPriority.HIGHEST)
   public void handle(final @NotNull PostLoginEvent event) {
     final Audience audience = SonarBungee.INSTANCE.getBungeeAudiences().player(event.getPlayer());
     Sonar.get().getVerboseHandler().getAudiences().put(event.getPlayer().getName(), audience);
   }
 
-  @EventHandler(priority = EventPriority.LOWEST)
+  @EventHandler(priority = EventPriority.HIGHEST)
   public void handle(final @NotNull PlayerDisconnectEvent event) {
     Sonar.get().getVerboseHandler().getAudiences().remove(event.getPlayer().getName());
   }

--- a/sonar-bungee/src/main/java/xyz/jonesdev/sonar/bungee/command/BungeeSonarCommand.java
+++ b/sonar-bungee/src/main/java/xyz/jonesdev/sonar/bungee/command/BungeeSonarCommand.java
@@ -32,7 +32,6 @@ public final class BungeeSonarCommand extends Command implements TabExecutor, So
   }
 
   @Override
-  @SuppressWarnings({"redundantSuppression"})
   public void execute(final @NotNull CommandSender sender, final String[] args) {
     // Create our own invocation source wrapper to handle messages properly
     final InvocationSource invocationSource = new BungeeInvocationSource(sender);

--- a/sonar-bungee/src/main/java/xyz/jonesdev/sonar/bungee/fallback/FallbackListener.java
+++ b/sonar-bungee/src/main/java/xyz/jonesdev/sonar/bungee/fallback/FallbackListener.java
@@ -22,6 +22,7 @@ import net.kyori.adventure.text.Component;
 import net.md_5.bungee.api.event.LoginEvent;
 import net.md_5.bungee.api.plugin.Listener;
 import net.md_5.bungee.event.EventHandler;
+import net.md_5.bungee.event.EventPriority;
 import org.jetbrains.annotations.NotNull;
 import xyz.jonesdev.sonar.api.Sonar;
 import xyz.jonesdev.sonar.bungee.SonarBungee;
@@ -32,8 +33,8 @@ import java.util.Objects;
 @RequiredArgsConstructor
 public final class FallbackListener implements Listener {
 
-  @EventHandler
   @SuppressWarnings("deprecation")
+  @EventHandler(priority = EventPriority.LOWEST)
   public void handle(final @NotNull LoginEvent event) {
     final InetAddress inetAddress = event.getConnection().getAddress().getAddress();
 


### PR DESCRIPTION
- Priority=LOWEST means that my listener is invoked at last which is not supposed to happen for the audience listener