### PR TITLE
Bump Velocity API from 3.2.0 to 3.3.0

### DIFF
--- a/sonar-velocity/build.gradle.kts
+++ b/sonar-velocity/build.gradle.kts
@@ -1,4 +1,4 @@
-val velocityVersion = "3.2.0-SNAPSHOT"
+val velocityVersion = "3.3.0-SNAPSHOT"
 
 dependencies {
   compileOnly(project(":api"))
@@ -26,5 +26,5 @@ tasks {
   }
 }
 
-java.sourceCompatibility = JavaVersion.VERSION_11
-java.targetCompatibility = JavaVersion.VERSION_11
+java.sourceCompatibility = JavaVersion.VERSION_17
+java.targetCompatibility = JavaVersion.VERSION_17


### PR DESCRIPTION
- Resolves https://github.com/jonesdevelopment/sonar/issues/137

If you want to use Sonar on Velocity 3.2.0, please use version 2.0.12 as any Velocity version below 3.3.0 won't be supported in the future.