### PR TITLE
Release 2.0.13

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 group=xyz.jonesdev.sonar
-version=2.0.12
+version=2.0.13
 description=Effective Anti-bot plugin for Velocity, BungeeCord, and Bukkit (1.7-latest)


### PR DESCRIPTION
- https://github.com/jonesdevelopment/sonar/pull/138

Since Velocity 3.3.0 changes some of its API as well as uses a different Java version (17), I decided that Sonar 2.0.13+ will no longer support Velocity 3.2.0 for security and stability reasons.