### PR TITLE
Fix license link in README

### DIFF
--- a/.github/README.md
+++ b/.github/README.md
@@ -25,7 +25,7 @@
   |
   [Discord](https://jonesdev.xyz/discord)
   |
-  [License](https://github.com/jonesdevelopment/sonar/blob/main/README.md#license)
+  [License](https://github.com/jonesdevelopment/sonar/?tab=readme-ov-file#license)
 </div>
 
 ## Design and Goal


### PR DESCRIPTION
- The license link in the README was broken since GitHub updated their UI