### PR TITLE
Fix protocol id check not using the correct disconnect method

### DIFF
--- a/sonar-bungee/src/main/java/xyz/jonesdev/sonar/bungee/fallback/FallbackUserWrapper.java
+++ b/sonar-bungee/src/main/java/xyz/jonesdev/sonar/bungee/fallback/FallbackUserWrapper.java
@@ -40,6 +40,12 @@ public final class FallbackUserWrapper implements FallbackUser<FallbackInitialHa
   private final InetAddress inetAddress;
   private final ProtocolVersion protocolVersion;
 
+  /**
+   * Disconnect the player during/after verification
+   * using our custom {@link Disconnect} packet.
+   *
+   * @param reason Disconnect message component
+   */
   @Override
   public void disconnect(final @NotNull Component reason) {
     connection.closeWith(Disconnect.create(reason));

--- a/sonar-velocity/src/main/java/xyz/jonesdev/sonar/velocity/fallback/FallbackListener.java
+++ b/sonar-velocity/src/main/java/xyz/jonesdev/sonar/velocity/fallback/FallbackListener.java
@@ -230,7 +230,8 @@ public final class FallbackListener {
 
           // Disconnect if the protocol version could not be resolved
           if (user.getProtocolVersion().isUnknown()) {
-            user.disconnect(Sonar.get().getConfig().getVerification().getInvalidProtocol());
+            mcConnection.closeWith(DisconnectPacket.create(Sonar.get().getConfig().getVerification().getInvalidProtocol(),
+              mcConnection.getProtocolVersion(), true));
             return;
           }
 

--- a/sonar-velocity/src/main/java/xyz/jonesdev/sonar/velocity/fallback/FallbackUserWrapper.java
+++ b/sonar-velocity/src/main/java/xyz/jonesdev/sonar/velocity/fallback/FallbackUserWrapper.java
@@ -43,6 +43,12 @@ public final class FallbackUserWrapper implements FallbackUser<MinecraftConnecti
   private final InetAddress inetAddress;
   private final ProtocolVersion protocolVersion;
 
+  /**
+   * Disconnect the player during/after verification
+   * using our custom {@link Disconnect} packet.
+   *
+   * @param reason Disconnect message component
+   */
   @Override
   public void disconnect(final @NotNull Component reason) {
     connection.closeWith(Disconnect.create(reason));


### PR DESCRIPTION
- https://github.com/jonesdevelopment/sonar/issues/167 was false, although it did led me to discover an actual issue with how Velocity handles the invalid protocol check