### PR TITLE
Bump adventure-platform to 4.3.2

### DIFF
--- a/sonar-bukkit/build.gradle.kts
+++ b/sonar-bukkit/build.gradle.kts
@@ -31,7 +31,7 @@ dependencies {
   compileOnly(project(":common"))
 
   // MiniMessage platform support
-  implementation("net.kyori:adventure-platform-bukkit:4.3.1")
+  implementation("net.kyori:adventure-platform-bukkit:4.3.2")
 
   // We have to use 1.8 for backwards compatibility
   compileOnly("org.spigotmc:spigot-api:1.8.8-R0.1-SNAPSHOT")

--- a/sonar-bungee/build.gradle.kts
+++ b/sonar-bungee/build.gradle.kts
@@ -19,7 +19,7 @@ dependencies {
   testCompileOnly("net.md_5:bungeecord-proxy:master-SNAPSHOT")
 
   // MiniMessage platform support
-  implementation("net.kyori:adventure-platform-bungeecord:4.3.1")
+  implementation("net.kyori:adventure-platform-bungeecord:4.3.2")
 
   // Implement bStats.org for metrics
   implementation("org.bstats:bstats-bungeecord:3.0.2")


### PR DESCRIPTION
- Fixes some issues regarding Minecraft 1.20.3+ components