### PR TITLE
Fix incompatibility with Velocity build 347+

### DIFF
--- a/sonar-velocity/src/main/resources/velocity-plugin.json
+++ b/sonar-velocity/src/main/resources/velocity-plugin.json
@@ -10,7 +10,7 @@
   ],
   "dependencies": [
     {
-      "id": "Geyser-Velocity",
+      "id": "geyser",
       "optional": true
     },
     {
@@ -18,11 +18,11 @@
       "optional": true
     },
     {
-      "id": "Protocolize",
+      "id": "protocolize",
       "optional": true
     },
     {
-      "id": "ViaVersion",
+      "id": "viaversion",
       "optional": true
     }
   ],


### PR DESCRIPTION
- Instead of the plugin IDs, I accidentally put the plugin names into `velocity-plugin.json`
- Since Velocity build 347, this causes an error making Sonar unable to boot