### PR TITLE
Release 2.0.17

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 group=xyz.jonesdev.sonar
-version=2.0.16
+version=2.0.17
 description=Effective Anti-bot plugin for Velocity, BungeeCord, and Bukkit (1.7-latest)


### PR DESCRIPTION
- #190 
- #189 
- #188 
- #187 
- #186 
- #185 
- #184 

Sonar now requires Java 11+ to run. You can read more detailed information on version support in the [documentation](<https://docs.jonesdev.xyz/sonar/supported-versions>).