### PR TITLE
Add experimental Geyser support

### DIFF
--- a/sonar-api/src/main/java/xyz/jonesdev/sonar/api/config/SonarConfiguration.java
+++ b/sonar-api/src/main/java/xyz/jonesdev/sonar/api/config/SonarConfiguration.java
@@ -213,6 +213,7 @@ public final class SonarConfiguration {
       Sonar.get().getLogger().info("Transferring 1.20.5+ clients is enabled. Please make sure to follow the instructions in order for this to work properly.");
     }
 
+    verification.checkGeyser = generalConfig.getBoolean("verification.check-geyser-players");
     verification.logConnections = generalConfig.getBoolean("verification.log-connections");
     verification.logDuringAttack = generalConfig.getBoolean("verification.log-during-attack");
     verification.debugXYZPositions = generalConfig.getBoolean("verification.debug-xyz-positions");
@@ -513,6 +514,7 @@ public final class SonarConfiguration {
       private int port;
     }
 
+    private boolean checkGeyser;
     private boolean logConnections;
     private boolean logDuringAttack;
     private boolean debugXYZPositions;

--- a/sonar-api/src/main/java/xyz/jonesdev/sonar/api/fallback/FallbackUser.java
+++ b/sonar-api/src/main/java/xyz/jonesdev/sonar/api/fallback/FallbackUser.java
@@ -40,6 +40,8 @@ public interface FallbackUser {
   @NotNull
   FallbackUserState getState();
 
+  boolean isGeyser();
+
   void setState(final FallbackUserState state);
 
   /**

--- a/sonar-api/src/main/java/xyz/jonesdev/sonar/api/fallback/FallbackUserState.java
+++ b/sonar-api/src/main/java/xyz/jonesdev/sonar/api/fallback/FallbackUserState.java
@@ -38,4 +38,8 @@ public enum FallbackUserState {
   public boolean canReceivePackets() {
     return this != FAILED && this != SUCCESS;
   }
+
+  public boolean shouldExpectMovement() {
+    return this != LOGIN_ACK && this != VEHICLE && this != CAPTCHA;
+  }
 }

--- a/sonar-api/src/main/java/xyz/jonesdev/sonar/api/fallback/FallbackUserState.java
+++ b/sonar-api/src/main/java/xyz/jonesdev/sonar/api/fallback/FallbackUserState.java
@@ -38,8 +38,4 @@ public enum FallbackUserState {
   public boolean canReceivePackets() {
     return this != FAILED && this != SUCCESS;
   }
-
-  public boolean shouldExpectMovement() {
-    return this != LOGIN_ACK && this != VEHICLE && this != CAPTCHA;
-  }
 }

--- a/sonar-common/src/main/java/xyz/jonesdev/sonar/common/fallback/FallbackChannelHandlerAdapter.java
+++ b/sonar-common/src/main/java/xyz/jonesdev/sonar/common/fallback/FallbackChannelHandlerAdapter.java
@@ -153,13 +153,12 @@ public class FallbackChannelHandlerAdapter extends ChannelInboundHandlerAdapter 
       return;
     }
 
-    // Completely skip Geyser connections
-    /*
-    if (GeyserUtil.isGeyserConnection(channel, socketAddress)) {
+    // Completely skip Geyser connections if configured
+    final boolean geyser = GeyserUtil.isGeyserConnection(channel, socketAddress);
+    if (geyser && !Sonar.get().getConfig().getVerification().isCheckGeyser()) {
       initialLogin(ctx, loginPacket, encoder, handler);
       return;
     }
-     */
 
     // Check if the player is already queued since we don't want bots to flood the queue
     if (FALLBACK.getQueue().getQueuedPlayers().containsKey(inetAddress)) {
@@ -214,7 +213,7 @@ public class FallbackChannelHandlerAdapter extends ChannelInboundHandlerAdapter 
       }
 
       // Create an instance for the Fallback connection
-      user = new FallbackUserWrapper(channel, inetAddress, protocolVersion, GeyserUtil.isGeyserConnection(channel, socketAddress));
+      user = new FallbackUserWrapper(channel, inetAddress, protocolVersion, geyser);
       // Let the verification handler take over the channel
       user.hijack(username, offlineUUID, encoder, decoder, timeout, handler);
     });

--- a/sonar-common/src/main/java/xyz/jonesdev/sonar/common/fallback/FallbackChannelHandlerAdapter.java
+++ b/sonar-common/src/main/java/xyz/jonesdev/sonar/common/fallback/FallbackChannelHandlerAdapter.java
@@ -154,10 +154,12 @@ public class FallbackChannelHandlerAdapter extends ChannelInboundHandlerAdapter 
     }
 
     // Completely skip Geyser connections
+    /*
     if (GeyserUtil.isGeyserConnection(channel, socketAddress)) {
       initialLogin(ctx, loginPacket, encoder, handler);
       return;
     }
+     */
 
     // Check if the player is already queued since we don't want bots to flood the queue
     if (FALLBACK.getQueue().getQueuedPlayers().containsKey(inetAddress)) {
@@ -212,7 +214,7 @@ public class FallbackChannelHandlerAdapter extends ChannelInboundHandlerAdapter 
       }
 
       // Create an instance for the Fallback connection
-      user = new FallbackUserWrapper(channel, inetAddress, protocolVersion);
+      user = new FallbackUserWrapper(channel, inetAddress, protocolVersion, GeyserUtil.isGeyserConnection(channel, socketAddress));
       // Let the verification handler take over the channel
       user.hijack(username, offlineUUID, encoder, decoder, timeout, handler);
     });

--- a/sonar-common/src/main/java/xyz/jonesdev/sonar/common/fallback/FallbackUserWrapper.java
+++ b/sonar-common/src/main/java/xyz/jonesdev/sonar/common/fallback/FallbackUserWrapper.java
@@ -55,19 +55,19 @@ public final class FallbackUserWrapper implements FallbackUser {
   private final ChannelPipeline pipeline;
   private final InetAddress inetAddress;
   private final ProtocolVersion protocolVersion;
-  private final boolean isGeyser;
+  private final boolean geyser;
   @Setter
   private FallbackUserState state = FallbackUserState.LOGIN_ACK; // 1.20.2+
 
   public FallbackUserWrapper(final @NotNull Channel channel,
                              final @NotNull InetAddress inetAddress,
                              final @NotNull ProtocolVersion protocolVersion,
-                             final boolean isGeyser) {
+                             final boolean geyser) {
     this.channel = channel;
     this.pipeline = channel.pipeline();
     this.inetAddress = inetAddress;
     this.protocolVersion = protocolVersion;
-    this.isGeyser = isGeyser;
+    this.geyser = geyser;
   }
 
   @Override
@@ -124,7 +124,7 @@ public final class FallbackUserWrapper implements FallbackUser {
 
       try {
         // Prepare custom packet decoder and verification handler
-        final FallbackVerificationHandler verification = new FallbackVerificationHandler(this, username, uuid, isGeyser);
+        final FallbackVerificationHandler verification = new FallbackVerificationHandler(this, username, uuid);
         final FallbackPacketDecoder fallbackPacketDecoder = new FallbackPacketDecoder(this, verification);
         // Replace normal decoder to allow custom packets
         pipeline.replace(decoder, FALLBACK_PACKET_DECODER, fallbackPacketDecoder);

--- a/sonar-common/src/main/java/xyz/jonesdev/sonar/common/fallback/FallbackUserWrapper.java
+++ b/sonar-common/src/main/java/xyz/jonesdev/sonar/common/fallback/FallbackUserWrapper.java
@@ -55,16 +55,19 @@ public final class FallbackUserWrapper implements FallbackUser {
   private final ChannelPipeline pipeline;
   private final InetAddress inetAddress;
   private final ProtocolVersion protocolVersion;
+  private final boolean isGeyser;
   @Setter
   private FallbackUserState state = FallbackUserState.LOGIN_ACK; // 1.20.2+
 
   public FallbackUserWrapper(final @NotNull Channel channel,
                              final @NotNull InetAddress inetAddress,
-                             final @NotNull ProtocolVersion protocolVersion) {
+                             final @NotNull ProtocolVersion protocolVersion,
+                             final boolean isGeyser) {
     this.channel = channel;
     this.pipeline = channel.pipeline();
     this.inetAddress = inetAddress;
     this.protocolVersion = protocolVersion;
+    this.isGeyser = isGeyser;
   }
 
   @Override
@@ -121,7 +124,7 @@ public final class FallbackUserWrapper implements FallbackUser {
 
       try {
         // Prepare custom packet decoder and verification handler
-        final FallbackVerificationHandler verification = new FallbackVerificationHandler(this, username, uuid);
+        final FallbackVerificationHandler verification = new FallbackVerificationHandler(this, username, uuid, isGeyser);
         final FallbackPacketDecoder fallbackPacketDecoder = new FallbackPacketDecoder(this, verification);
         // Replace normal decoder to allow custom packets
         pipeline.replace(decoder, FALLBACK_PACKET_DECODER, fallbackPacketDecoder);

--- a/sonar-common/src/main/java/xyz/jonesdev/sonar/common/fallback/FallbackVerificationHandler.java
+++ b/sonar-common/src/main/java/xyz/jonesdev/sonar/common/fallback/FallbackVerificationHandler.java
@@ -493,7 +493,7 @@ public final class FallbackVerificationHandler implements FallbackPacketListener
     }
 
     // Only handle position packets if we aren't in certain phases
-    if (user.getState().shouldExpectMovement()) {
+    if (user.getState() != LOGIN_ACK && user.getState() != VEHICLE) {
       if (packet instanceof PlayerPositionPacket) {
         final PlayerPositionPacket position = (PlayerPositionPacket) packet;
         handlePositionUpdate(position.getX(), position.getY(), position.getZ(), position.isOnGround());

--- a/sonar-common/src/main/java/xyz/jonesdev/sonar/common/fallback/FallbackVerificationHandler.java
+++ b/sonar-common/src/main/java/xyz/jonesdev/sonar/common/fallback/FallbackVerificationHandler.java
@@ -347,7 +347,7 @@ public final class FallbackVerificationHandler implements FallbackPacketListener
       // pre-1.9 clients do not have a PaddleBoat packet
       if (user.getProtocolVersion().compareTo(MINECRAFT_1_9) < 0) {
         receivedSteerBoat = true;
-      } else {
+      } else if (!user.isGeyser()) {
         // PaddleBoat → PlayerInput → PaddleBoat
         checkFrame(receivedSteerBoat, "invalid vehicle steering order");
       }

--- a/sonar-common/src/main/java/xyz/jonesdev/sonar/common/fallback/FallbackVerificationHandler.java
+++ b/sonar-common/src/main/java/xyz/jonesdev/sonar/common/fallback/FallbackVerificationHandler.java
@@ -493,8 +493,9 @@ public final class FallbackVerificationHandler implements FallbackPacketListener
     }
 
     // Only handle position packets if we aren't in the configuration phase (1.20.2+)
-    // Additionally, we don't want top check Geyser players for gravity, as this
-    // might cause issues because of the protocol differences.
+    // Additionally, we don't want to check Geyser players for valid gravity, as this
+    // might cause issues because of the different protocol → Bedrock is UDP
+    // TODO: Find a suitable solution for this, or simply remove this comment :)
     if (user.getState() != LOGIN_ACK && !user.isGeyser()) {
       if (packet instanceof PlayerPositionPacket) {
         final PlayerPositionPacket position = (PlayerPositionPacket) packet;

--- a/sonar-common/src/main/java/xyz/jonesdev/sonar/common/fallback/FallbackVerificationHandler.java
+++ b/sonar-common/src/main/java/xyz/jonesdev/sonar/common/fallback/FallbackVerificationHandler.java
@@ -689,7 +689,7 @@ public final class FallbackVerificationHandler implements FallbackPacketListener
     // Teleport the player to the position above the platform
     user.delayedWrite(CAPTCHA_POSITION);
     // Make sure the player cannot move
-    user.delayedWrite(CAPTCHA_ABILITIES);
+    user.delayedWrite(isGeyser ? CAPTCHA_ABILITIES_BEDROCK : CAPTCHA_ABILITIES);
     // Make sure the player knows what to do
     user.delayedWrite(enterCodeMessage);
     // Send all packets in one flush

--- a/sonar-common/src/main/java/xyz/jonesdev/sonar/common/fallback/FallbackVerificationHandler.java
+++ b/sonar-common/src/main/java/xyz/jonesdev/sonar/common/fallback/FallbackVerificationHandler.java
@@ -648,7 +648,7 @@ public final class FallbackVerificationHandler implements FallbackPacketListener
           tick, y, offsetY, deltaY, predictedY));
 
         // First correct gravity tick → Geyser player has spawned
-        if (user.isGeyser()) {
+        if (!bedrockSpawned && user.isGeyser()) {
           bedrockSpawned = true;
         }
       }

--- a/sonar-common/src/main/java/xyz/jonesdev/sonar/common/fallback/FallbackVerificationHandler.java
+++ b/sonar-common/src/main/java/xyz/jonesdev/sonar/common/fallback/FallbackVerificationHandler.java
@@ -86,7 +86,8 @@ public final class FallbackVerificationHandler implements FallbackPacketListener
     this.user = user;
     this.username = username;
     this.playerUuid = playerUuid;
-    this.performGravity = Sonar.get().getConfig().getVerification().getGravity().isEnabled();
+    // We don't want to check Geyser players for valid gravity, as this might cause issues because of the protocol
+    this.performGravity = !user.isGeyser() && Sonar.get().getConfig().getVerification().getGravity().isEnabled();
     this.performCollisions = Sonar.get().getConfig().getVerification().getGravity().isCheckCollisions();
     this.performCaptcha = FALLBACK.shouldPerformCaptcha();
     this.performVehicle = FALLBACK.shouldPerformVehicleCheck();
@@ -539,12 +540,6 @@ public final class FallbackVerificationHandler implements FallbackPacketListener
       // Check if the client hasn't moved before sending the first movement packet
       if (!listenForMovements) {
         if (posX == SPAWN_X_POSITION && posZ == SPAWN_Z_POSITION) {
-          // We don't want to check Geyser players for valid gravity, as this might
-          // cause issues because of the different protocol → Bedrock is UDP
-          if (user.isGeyser()) {
-            vehicleCheckOrNext();
-            return;
-          }
           // Now, once we verified the X and Z position, we can safely check for gravity
           listenForMovements = true;
         }

--- a/sonar-common/src/main/java/xyz/jonesdev/sonar/common/fallback/FallbackVerificationHandler.java
+++ b/sonar-common/src/main/java/xyz/jonesdev/sonar/common/fallback/FallbackVerificationHandler.java
@@ -622,7 +622,7 @@ public final class FallbackVerificationHandler implements FallbackPacketListener
             // This may result in an instant bypass of the gravity check.
             // Perhaps ignorable ticks should be restricted.
             final long maxIgnoreTick = (System.currentTimeMillis() - login.getStart() + 100L) / 50L;
-            for (int i = (tick + 1); (i < preparedCachedYMotions.length && (tick - 1) <= maxIgnoreTick); i++) {
+            for (int i = (tick + 1); (i < preparedCachedYMotions.length && (i - tick) <= maxIgnoreTick); i++) {
               final double newPredictedY = preparedCachedYMotions[i];
               if ((deltaY - newPredictedY) < 0.005) {
                 tick=i;
@@ -638,9 +638,11 @@ public final class FallbackVerificationHandler implements FallbackPacketListener
             }
           }
         }
-        bedrockSpawned=true;
         checkFrame(isSuccess, String.format("invalid gravity: %d, %.7f, %.10f, %.10f != %.10f",
           tick, y, offsetY, deltaY, predictedY));
+        if (isGeyser) {
+          bedrockSpawned=true;
+        }
       }
       tick++;
     } catch (CorruptedFrameException exception) {

--- a/sonar-common/src/main/java/xyz/jonesdev/sonar/common/fallback/FallbackVerificationHandler.java
+++ b/sonar-common/src/main/java/xyz/jonesdev/sonar/common/fallback/FallbackVerificationHandler.java
@@ -610,13 +610,14 @@ public final class FallbackVerificationHandler implements FallbackPacketListener
         }
 
         // Check if the y motion is roughly equal to the predicted value
-        if (isGeyser && !bedrockSpawned) {
-          bedrockSpawned=true;
+        final boolean isSuccess = (offsetY < 0.005);
+        if (!isSuccess && isGeyser && !bedrockSpawned) {
           tick=0;
         } else {
           checkFrame(offsetY < 0.005, String.format("invalid gravity: %d, %.7f, %.10f, %.10f != %.10f",
             tick, y, offsetY, deltaY, predictedY));
         }
+        bedrockSpawned=true;
       }
       tick++;
     } catch (CorruptedFrameException exception) {

--- a/sonar-common/src/main/java/xyz/jonesdev/sonar/common/fallback/FallbackVerificationHandler.java
+++ b/sonar-common/src/main/java/xyz/jonesdev/sonar/common/fallback/FallbackVerificationHandler.java
@@ -606,14 +606,16 @@ public final class FallbackVerificationHandler implements FallbackPacketListener
             username, x, y, z, deltaY, predictedY, offsetY);
         }
 
-        // Check if the y motion is roughly equal to the predicted value
-        boolean isSuccess = (offsetY < 0.005);
+        // TODO: make this actually somewhat readable
+        boolean isSuccess = offsetY < 0.005;
         if (!isSuccess && user.isGeyser() && !bedrockSpawned) {
           final boolean debug = Sonar.get().getConfig().getVerification().isDebugXYZPositions();
           if (Math.abs(deltaY) < 0.0001) {
-            tick=0; // spawn with wrong position. reset tick.
-            isSuccess=true;
-            if (debug) { FALLBACK.getLogger().info("Ignoring caused by first position is wrong. (deltaY: {})", deltaY); }
+            tick = 0; // spawn with wrong position; reset tick
+            isSuccess = true;
+            if (debug) {
+              FALLBACK.getLogger().info("Ignoring caused by first position is wrong. (deltaY: {})", deltaY);
+            }
           } else {
             final int oldTick = tick;
             // This may result in an instant bypass of the gravity check.
@@ -622,23 +624,28 @@ public final class FallbackVerificationHandler implements FallbackPacketListener
             for (int i = (tick + 1); (i < preparedCachedYMotions.length && (i - tick) <= maxIgnoreTick); i++) {
               final double newPredictedY = preparedCachedYMotions[i];
               if ((deltaY - newPredictedY) < 0.005) {
-                tick=i;
+                tick = i;
                 break;
               }
             }
+
             //checkFrame(oldTick != tick, "too many movements");
-            isSuccess = (tick > oldTick);
-            if (isSuccess && debug)
-            { FALLBACK.getLogger().info(
+            isSuccess = tick > oldTick;
+
+            if (isSuccess && debug) { FALLBACK.getLogger().info(
               "Skipping {} tick(s) for bedrock client. (deltaY: {} - prediction: {})",
               tick - oldTick, deltaY, preparedCachedYMotions[tick]);
             }
           }
         }
+
+        // Check if the y motion is roughly equal to the predicted value
         checkFrame(isSuccess, String.format("invalid gravity: %d, %.7f, %.10f, %.10f != %.10f",
           tick, y, offsetY, deltaY, predictedY));
+
+        // First correct gravity tick → Geyser player has spawned
         if (user.isGeyser()) {
-          bedrockSpawned=true;
+          bedrockSpawned = true;
         }
       }
       tick++;

--- a/sonar-common/src/main/java/xyz/jonesdev/sonar/common/fallback/FallbackVerificationHandler.java
+++ b/sonar-common/src/main/java/xyz/jonesdev/sonar/common/fallback/FallbackVerificationHandler.java
@@ -484,8 +484,7 @@ public final class FallbackVerificationHandler implements FallbackPacketListener
 
       // Reset all values to ensure safety on teleport
       tick = 1;
-      posY = lastY = -1;
-      expectedTeleportId = -1;
+      posY = lastY = expectedTeleportId = -1;
 
       // Now we can send the chunk data
       sendChunkData();
@@ -522,8 +521,7 @@ public final class FallbackVerificationHandler implements FallbackPacketListener
         && x == SPAWN_X_POSITION && y == spawnYPosition && z == SPAWN_Z_POSITION) {
         // Reset all values to ensure safety on teleport
         tick = 1;
-        posY = -1;
-        expectedTeleportId = -1;
+        posY = expectedTeleportId = -1;
         // Check for ground state in the first packet
         checkFrame(!ground, "invalid ground state");
       }

--- a/sonar-common/src/main/java/xyz/jonesdev/sonar/common/fallback/protocol/FallbackPreparer.java
+++ b/sonar-common/src/main/java/xyz/jonesdev/sonar/common/fallback/protocol/FallbackPreparer.java
@@ -38,6 +38,7 @@ public class FallbackPreparer {
   // Abilities
   public final FallbackPacket DEFAULT_ABILITIES = new ClientAbilitiesPacket(0x00, 0f, 0f);
   public final FallbackPacket CAPTCHA_ABILITIES = new ClientAbilitiesPacket(0x02, 0f, 0f);
+  public final FallbackPacket CAPTCHA_ABILITIES_BEDROCK = new ClientAbilitiesPacket(0x06, 0f, 0f);
   // Chunks
   public final FallbackPacket EMPTY_CHUNK_DATA = new ChunkDataPacket(0, 0);
   // Finish Configuration

--- a/sonar-common/src/main/resources/assets/config/cs.yml
+++ b/sonar-common/src/main/resources/assets/config/cs.yml
@@ -183,6 +183,10 @@ verification:
   # Měl by Sonar posílat každý jeden pohyb při verifikaci?
   # Toto nastavení není doporučeno pro servry v produkci, ale může být nápomocné při vyhledávaní chyb
   debug-xyz-positions: false
+  # Should Sonar also check Geyser (Bedrock) players?
+  # This feature is experimental and might cause issues
+  # If this is disabled, Bedrock players will be skipped
+  check-geyser-players: true
   # Množství času který musí uběhnout aby hráč byl odpojen
   # (Hodnota udávaná v milisekundách: 1 sekunda = 1000 milisekund)
   read-timeout: 8000

--- a/sonar-common/src/main/resources/assets/config/cs.yml
+++ b/sonar-common/src/main/resources/assets/config/cs.yml
@@ -130,7 +130,7 @@ verification:
       # Kolikrát musí hráč selhat CAPTCHU před celkovém selhání verifikace?
       max-tries: 3
       # Znaky (čísla a písmena), které jsou povoleny k zobrazování v CAPTCHE
-      # It is not recommended to add numbers or letters that might look like one another
+      # Nedoporučuje se přidávat čísla nebo písmena, která by se mohla navzájem podobat
       dictionary: '1235689'
       # Jaké typy fontů by měl Sonar používat pro map CAPTCHU?
       font-names:

--- a/sonar-common/src/main/resources/assets/config/cs.yml
+++ b/sonar-common/src/main/resources/assets/config/cs.yml
@@ -89,12 +89,12 @@ verification:
       # - ADVENTURE: všechny komponenty UI jsou zobrazeny
       gamemode: ADVENTURE
 
-    # Checks if the client sends proper packets when mounting a vehicle
+    # Kontroluje, zda klient odesílá správné pakety při montáži vozidla
     vehicle:
-      # Possible types: ALWAYS, DURING_ATTACK, NEVER
-      # - ALWAYS: New players will always be mounted on a vehicle
-      # - DURING_ATTACK: New players will only be mounted on a vehicle during an attack
-      # - NEVER: New players will never be mounted on a vehicle (Recommended)
+      # Typy: ALWAYS, DURING_ATTACK, NEVER
+      # - ALWAYS: Noví hráči budou vždy namontováni na vozidle (Doporučeno)
+      # - DURING_ATTACK: Noví hráči budou namontováni na vozidlo pouze během útoku
+      # - NEVER: Noví hráči nebudou nikdy namontováni na vozidlo
       timing: ALWAYS
 
     # Nechá hráče verifikovat pomocí kódu na mapě ve hře
@@ -105,21 +105,21 @@ verification:
       # - DURING_ATTACK: Noví hráči dostanou map captchu jenom při útoku
       # - NEVER: Noví hráči nikdy nedostanou map CAPTCHU (Doporučeno)
       timing: NEVER
-      # Options for the effects on the image shown to the player
+      # Možnosti efektů na obrázek zobrazený přehrávači
       effects:
-        # Adds a glow effect to the image
+        # Přidá do obrázku efekt záře
         flare: true
-        # Adds random lines to the image
+        # Přidá do obrázku náhodné čáry
         scratches: true
-        # Applies a ripple (sine) distortion filter
+        # Přidá filtr zvlnění (sinus) zkreslení
         ripple: true
-        # Applies a horizontal distortion filter
+        # Přidá horizontální filtr zkreslení
         smear: true
-        # Adds a bit of blurriness/distortion to the image
+        # Dodává obrazu trochu rozmazání/zkreslení
         pinch: true
-        # Applies color correction (color saturation)
+        # Použije korekci barev (sytost barev)
         saturation: 0.15
-        # Applies a horizontal triangular ripple filter
+        # Přidá horizontální trojúhelníkový filtr zvlnění
         distortion: 2
       # Kolik odpovědí by měl Sonar předgenerovat?
       # Tento úkol běží souběžně v pozadí
@@ -148,9 +148,9 @@ verification:
       # Maximální délka "client brand" při verifikaci
       max-length: 64
 
-    # Regex for validování jmen při verifikaci
+    # Regex pro validování jmen při verifikaci
     valid-name-regex: ^[a-zA-Z0-9_]+$
-    # Regex for validaci "client locale" při verifikaci
+    # Regex pro validaci "client locale" při verifikaci
     valid-locale-regex: ^[a-zA-Z_]+$
     # Maximální odezva hráče aby byl odpojen
     # (Hodnota udávaná v milisekundách: 1 sekunda = 1000 milisekund)
@@ -158,22 +158,22 @@ verification:
     # Maximální počet login packetů, který musí hřáč poslat aby byl vyhozen
     max-login-packets: 256
 
-  # If enabled, the player will be transferred back to the origin server
-  # after successfully passing the bot verification.
-  # This feature was introduced by Mojang in Minecraft version 1.20.5
+  # Je-li povoleno, přehrávač bude přenesen zpět na původní server
+  # po úspěšném absolvování ověření robota.
+  # Tuto funkci představil Mojang ve verzi Minecraft 1.20.5
   transfer:
-    # Should Sonar transfer the player to the origin server (instead of kicking them)?
-    # For this to work, you must enable the feature in your server's configuration
-    # Additionally, you might want to reduce the amount of login rate-limiting
-    # performed by Velocity or other proxies/plugins, as this might prevent the
-    # player from being transferred correctly.
+    # Měl by Sonar přenést hráče na původní server (místo toho, aby je kopl)?
+    # Aby to fungovalo, musíte tuto funkci povolit v konfiguraci vašeho serveru
+    # Kromě toho možná budete chtít snížit množství omezení rychlosti přihlášení
+    # provádí Velocity nebo jiné proxy/pluginy, protože to může zabránit
+    # hráč nebyl převeden správně.
     enabled: false
-    # Which server should Sonar transfer the player to when the verification is passed?
-    # Please enter the server IP that is used by players to normally connect to your server.
-    # For example, you can put "mc.hypixel.net" or a direct IP like "1.1.1.1"
+    # Na který server by měl Sonar přenést přehrávač, když projde ověřením?
+    # Zadejte IP serveru, který hráči používají k běžnému připojení k vašemu serveru.
+    # Například můžete zadat "mc.hypixel.net" nebo přímou IP jako "1.1.1.1"
     destination-host: "play.my-server.com"
-    # Which port should Sonar use when transferring the player to the origin server?
-    # If your server does not need a port to connect to, you can leave this as 25565.
+    # Jaký port by měl Sonar použít při přenosu přehrávače na původní server?
+    # Pokud váš server nepotřebuje port pro připojení, můžete toto ponechat jako 25565.
     destination-port: 25565
 
   # Měl by Sonar posílat nové verifikace?
@@ -183,17 +183,17 @@ verification:
   # Měl by Sonar posílat každý jeden pohyb při verifikaci?
   # Toto nastavení není doporučeno pro servry v produkci, ale může být nápomocné při vyhledávaní chyb
   debug-xyz-positions: false
-  # Should Sonar also check Geyser (Bedrock) players?
-  # This feature is experimental and might cause issues
-  # If this is disabled, Bedrock players will be skipped
+  # Měl by Sonar také kontrolovat hráče Geyser (Bedrock)?
+  # Tato funkce je experimentální a může způsobit problémy
+  # Pokud je toto zakázáno, hráči Bedrock budou přeskočeni
   check-geyser-players: true
   # Množství času který musí uběhnout aby hráč byl odpojen
   # (Hodnota udávaná v milisekundách: 1 sekunda = 1000 milisekund)
   read-timeout: 8000
-  # How long should a player wait before reconnecting during verification Jak dlouho by měl hráč
+  # Jak dlouho by měl hráč čekat, než se při ověřování znovu připojí
   # (Hodnota udávaná v milisekundách: 1 sekunda = 1000 milisekund)
   rejoin-delay: 8000
-  # How long should Sonar remember the amount of failed verifications for a player?
+  # Jak dlouho by si měl Sonar pamatovat počet neúspěšných ověření hráče?
   # (Hodnota udávaná v milisekundách: 1 sekunda = 1000 milisekund)
   remember-time: 120000
   # Jak dlouho by měla být IP adresa zakázána k připojení po selhání verifikace mockrát?

--- a/sonar-common/src/main/resources/assets/config/de.yml
+++ b/sonar-common/src/main/resources/assets/config/de.yml
@@ -86,12 +86,12 @@ verification:
       # - ADVENTURE: alle UI-Komponenten sind sichtbar
       gamemode: ADVENTURE
 
-    # Checks if the client sends proper packets when mounting a vehicle
+    # Überprüft, ob der Spieler beim Einsteigen in ein Boot die richtigen Pakete sendet
     vehicle:
-      # Possible types: ALWAYS, DURING_ATTACK, NEVER
-      # - ALWAYS: New players will always be mounted on a vehicle
-      # - DURING_ATTACK: New players will only be mounted on a vehicle during an attack
-      # - NEVER: New players will never be mounted on a vehicle (Recommended)
+      # Mögliche Typen: ALWAYS, DURING_ATTACK, NEVER
+      # - ALWAYS: Neue Spieler werden immer auf einem Fahrzeug montiert (Empfohlen)
+      # - DURING_ATTACK: Neue Spieler werden nur während eines Angriffs auf ein Fahrzeug gesetzt
+      # - NEVER: Neue Spieler werden niemals in ein Fahrzeug eingebaut
       timing: ALWAYS
 
     # Lässt den Spieler einen Code von einer virtuellen Karte im Chat eingeben
@@ -102,21 +102,21 @@ verification:
       # - DURING_ATTACK: Neue Spieler erhalten nur während eines Angriffs ein CAPTCHA
       # - NEVER: Neue Spieler erhalten nie ein CAPTCHA (Empfohlen)
       timing: NEVER
-      # Options for the effects on the image shown to the player
+      # Optionen für die Effekte auf das dem Player angezeigte Bild
       effects:
-        # Adds a glow effect to the image
+        # Fügt dem Bild einen Leuchteffekt hinzu
         flare: true
-        # Adds random lines to the image
+        # Fügt dem Bild zufällige Linien hinzu
         scratches: true
-        # Applies a ripple (sine) distortion filter
+        # Wendet einen Sinus-Verzerrungsfilter an
         ripple: true
-        # Applies a horizontal distortion filter
+        # Wendet einen horizontalen Verzerrungsfilter an
         smear: true
-        # Adds a bit of blurriness/distortion to the image
+        # Fügt dem Bild etwas Unschärfe/Verzerrung hinzu
         pinch: true
-        # Applies color correction (color saturation)
+        # Wendet eine Farbkorrektur an (Farbsättigung)
         saturation: 0.15
-        # Applies a horizontal triangular ripple filter
+        # Wendet einen horizontalen dreieckigen Wellenfilter an
         distortion: 2
       # Wie viele Antworten soll Sonar vorbereiten?
       # Dieser Vorgang erfolgt asynchron im Hintergrund
@@ -155,22 +155,22 @@ verification:
     # Maximale Anzahl an Login-Paketen, die der Spieler senden muss, um gekickt zu werden
     max-login-packets: 256
 
-  # If enabled, the player will be transferred back to the origin server
-  # after successfully passing the bot verification.
-  # This feature was introduced by Mojang in Minecraft version 1.20.5
+  # Wenn aktiviert, wird der Player zurück zum Ursprungsserver gesendet
+  # falls dieser die der Bot-Verifizierung erfolgreich besteht.
+  # Diese Funktion wurde von Mojang in Minecraft Version 1.20.5 eingeführt
   transfer:
-    # Should Sonar transfer the player to the origin server (instead of kicking them)?
-    # For this to work, you must enable the feature in your server's configuration
-    # Additionally, you might want to reduce the amount of login rate-limiting
-    # performed by Velocity or other proxies/plugins, as this might prevent the
-    # player from being transferred correctly.
+    # Sollte Sonar den Spieler auf den Ursprungsserver senden (anstatt ihn zu kicken)?
+    # Damit dies funktioniert, müssen Sie die Funktion in der Konfiguration Ihres Servers aktivieren
+    # Darüber hinaus möchten Sie möglicherweise die Begrenzung der Anmelderate reduzieren
+    # wird von Velocity oder anderen Proxys/Plugins durchgeführt, da dies das verhindern könnte
+    # Spieler konnte nicht korrekt übertragen werden.
     enabled: false
-    # Which server should Sonar transfer the player to when the verification is passed?
-    # Please enter the server IP that is used by players to normally connect to your server.
-    # For example, you can put "mc.hypixel.net" or a direct IP like "1.1.1.1"
+    # Auf welchen Server soll Sonar den Spieler übertragen, wenn die Verifizierung bestanden wurde?
+    # Bitte geben Sie die Server-IP ein, die von Spielern verwendet wird, um sich zu verbinden.
+    # Sie können beispielsweise "mc.hypixel.net" oder eine direkte IP wie "1.1.1.1" verwenden.
     destination-host: "play.my-server.com"
-    # Which port should Sonar use when transferring the player to the origin server?
-    # If your server does not need a port to connect to, you can leave this as 25565.
+    # Welchen Port sollte Sonar verwenden, wenn der Spieler auf den Ursprungsserver gesendet wird?
+    # Wenn Ihr Server keinen Port zum Herstellen einer Verbindung benötigt, können Sie diesen auf 25565 belassen.
     destination-port: 25565
 
   # Soll Sonar neue Überprüfungsversuche protokollieren?
@@ -180,9 +180,9 @@ verification:
   # Soll Sonar jede einzelne Bewegung/Positionsänderung während der Überprüfung protokollieren?
   # Dies wird für Produktivserver nicht empfohlen, kann aber beim Auffinden von Fehlern hilfreich sein.
   debug-xyz-positions: false
-  # Should Sonar also check Geyser (Bedrock) players?
-  # This feature is experimental and might cause issues
-  # If this is disabled, Bedrock players will be skipped
+  # Sollte Sonar auch Geyser (Bedrock)-Spieler überprüfen?
+  # Diese Funktion ist experimentell und kann Probleme verursachen
+  # Wenn dies deaktiviert ist, werden Bedrock-Spieler übersprungen
   check-geyser-players: true
   # Zeit, die verstreichen muss, bevor ein Spieler ein Timeout erleidet
   # (Dieser Wert stellt die Zeit in Millisekunden dar: 1 Sekunde = 1000 Millisekunden)

--- a/sonar-common/src/main/resources/assets/config/de.yml
+++ b/sonar-common/src/main/resources/assets/config/de.yml
@@ -180,6 +180,10 @@ verification:
   # Soll Sonar jede einzelne Bewegung/Positionsänderung während der Überprüfung protokollieren?
   # Dies wird für Produktivserver nicht empfohlen, kann aber beim Auffinden von Fehlern hilfreich sein.
   debug-xyz-positions: false
+  # Should Sonar also check Geyser (Bedrock) players?
+  # This feature is experimental and might cause issues
+  # If this is disabled, Bedrock players will be skipped
+  check-geyser-players: true
   # Zeit, die verstreichen muss, bevor ein Spieler ein Timeout erleidet
   # (Dieser Wert stellt die Zeit in Millisekunden dar: 1 Sekunde = 1000 Millisekunden)
   read-timeout: 8000

--- a/sonar-common/src/main/resources/assets/config/de.yml
+++ b/sonar-common/src/main/resources/assets/config/de.yml
@@ -127,7 +127,7 @@ verification:
       # Wie oft muss ein Spieler das CAPTCHA nicht bestehen, bevor er die Überprüfung nicht besteht?
       max-tries: 3
       # Zeichen (Buchstaben und Zahlen), die im Antwort-CAPTCHA erscheinen dürfen
-      # It is not recommended to add numbers or letters that might look like one another
+      # Es wird nicht empfohlen, Zahlen oder Buchstaben hinzuzufügen, die einander ähneln könnten
       dictionary: '1235689'
       # Welche Schriftarten soll Sonar für die Map-CAPTCHA-Codes verwenden?
       font-names:

--- a/sonar-common/src/main/resources/assets/config/en.yml
+++ b/sonar-common/src/main/resources/assets/config/en.yml
@@ -91,9 +91,9 @@ verification:
     # Checks if the client sends proper packets when mounting a vehicle
     vehicle:
       # Possible types: ALWAYS, DURING_ATTACK, NEVER
-      # - ALWAYS: New players will always be mounted on a vehicle
+      # - ALWAYS: New players will always be mounted on a vehicle (Recommended)
       # - DURING_ATTACK: New players will only be mounted on a vehicle during an attack
-      # - NEVER: New players will never be mounted on a vehicle (Recommended)
+      # - NEVER: New players will never be mounted on a vehicle
       timing: ALWAYS
 
     # Make the player type a code from a virtual map in chat

--- a/sonar-common/src/main/resources/assets/config/en.yml
+++ b/sonar-common/src/main/resources/assets/config/en.yml
@@ -182,6 +182,10 @@ verification:
   # Should Sonar log every single movement/position change during verification?
   # This is not recommended for production servers but can be helpful for spotting errors.
   debug-xyz-positions: false
+  # Should Sonar also check Geyser (Bedrock) players?
+  # This feature is experimental and might cause issues
+  # If this is disabled, Bedrock players will be skipped
+  check-geyser-players: true
   # Amount of time that has to pass before a player times out
   # (This value represents the time in milliseconds: 1 second = 1000 milliseconds)
   read-timeout: 8000

--- a/sonar-common/src/main/resources/assets/config/ka.yml
+++ b/sonar-common/src/main/resources/assets/config/ka.yml
@@ -91,9 +91,9 @@ verification:
     # Checks if the client sends proper packets when mounting a vehicle
     vehicle:
       # Possible types: ALWAYS, DURING_ATTACK, NEVER
-      # - ALWAYS: New players will always be mounted on a vehicle
+      # - ALWAYS: New players will always be mounted on a vehicle (Recommended)
       # - DURING_ATTACK: New players will only be mounted on a vehicle during an attack
-      # - NEVER: New players will never be mounted on a vehicle (Recommended)
+      # - NEVER: New players will never be mounted on a vehicle
       timing: ALWAYS
 
     # დააწერინეთ მოთამაშეს კოდი ჩატში, რომელიც იქნება ნაჩვენები ვირტუალურ მაპზე, რომელიც ხელში ეჭირებად

--- a/sonar-common/src/main/resources/assets/config/ka.yml
+++ b/sonar-common/src/main/resources/assets/config/ka.yml
@@ -182,6 +182,10 @@ verification:
   # ჩაიწეროს თუ არა Sonar-მა ყოველი მოძრაობა/პოზიცია ვერიფიკაციის დროს?
   # ეს არ არის რეკომენდირებული აქტიურ სერვერებისთვის, მაგრამ შეიძლება გამოსადეგი იყოს ცრუ პოსიტივების გამოსასწორებლად.
   debug-xyz-positions: false
+  # Should Sonar also check Geyser (Bedrock) players?
+  # This feature is experimental and might cause issues
+  # If this is disabled, Bedrock players will be skipped
+  check-geyser-players: true
   # დროის ოდენობა, რომელიც უნდა გავიდეს, სანამ მოთამაშე ტაიმაუტდება სერვერიდან.
   # (ეს არის ნაჩვენები მილიწამებში: 1 წამი = 1000 მილიწამი)
   read-timeout: 8000

--- a/sonar-common/src/main/resources/assets/config/ru.yml
+++ b/sonar-common/src/main/resources/assets/config/ru.yml
@@ -182,6 +182,10 @@ verification:
   # Должен ли Sonar регистрировать каждое движение/изменение положения во время проверки?
   # Это не рекомендуется для рабочих серверов, но может быть полезно для выявления ошибок.
   debug-xyz-positions: false
+  # Should Sonar also check Geyser (Bedrock) players?
+  # This feature is experimental and might cause issues
+  # If this is disabled, Bedrock players will be skipped
+  check-geyser-players: true
   # Количество времени, которое должно пройти, прежде чем игрока кикнет.
   # (Это значение представляет время в миллисекундах: 1 секунда = 1000 миллисекунд)
   read-timeout: 8000

--- a/sonar-common/src/main/resources/assets/config/ru.yml
+++ b/sonar-common/src/main/resources/assets/config/ru.yml
@@ -91,9 +91,9 @@ verification:
     # Checks if the client sends proper packets when mounting a vehicle
     vehicle:
       # Possible types: ALWAYS, DURING_ATTACK, NEVER
-      # - ALWAYS: New players will always be mounted on a vehicle
+      # - ALWAYS: New players will always be mounted on a vehicle (Recommended)
       # - DURING_ATTACK: New players will only be mounted on a vehicle during an attack
-      # - NEVER: New players will never be mounted on a vehicle (Recommended)
+      # - NEVER: New players will never be mounted on a vehicle
       timing: ALWAYS
 
     # Заставить игрока ввести код с картинки в чат

--- a/sonar-common/src/main/resources/assets/config/zh.yml
+++ b/sonar-common/src/main/resources/assets/config/zh.yml
@@ -175,6 +175,10 @@ verification:
   # Sonar 是否应该记录验证过程中玩家的移动位置的变化?
   # 有助于发现错误 但不建议在非调试环境下的服务器启用该选项.
   debug-xyz-positions: false
+  # Should Sonar also check Geyser (Bedrock) players?
+  # This feature is experimental and might cause issues
+  # If this is disabled, Bedrock players will be skipped
+  check-geyser-players: true
   # 要在客户端未响应多少毫秒后因超时而被踢出服务器?
   # (该值为毫秒. 1秒等于1000毫秒.)
   read-timeout: 8000

--- a/sonar-common/src/main/resources/assets/config/zh.yml
+++ b/sonar-common/src/main/resources/assets/config/zh.yml
@@ -175,9 +175,9 @@ verification:
   # Sonar 是否应该记录验证过程中玩家的移动位置的变化?
   # 有助于发现错误 但不建议在非调试环境下的服务器启用该选项.
   debug-xyz-positions: false
-  # Should Sonar also check Geyser (Bedrock) players?
-  # This feature is experimental and might cause issues
-  # If this is disabled, Bedrock players will be skipped
+  # Sonar 是否应该检查来自 Geyser 的(基岩版)玩家?
+  # 此功能是实验性的. 请报告任何因为误判而导致无法通过检查的问题
+  # 如果关闭该选项 Sonar 将不检查这些玩家以便直接连接到服务器.
   check-geyser-players: true
   # 要在客户端未响应多少毫秒后因超时而被踢出服务器?
   # (该值为毫秒. 1秒等于1000毫秒.)


### PR DESCRIPTION
Closes #263 

Added experimental support for bedrock client checks.

Not much has changed. In testing. The client sends an incorrect position on spawning (exclude it and reset the tick. Then it can be inspected just like a java client).

It also exempts Geyser from brand and client settings checks. They don't seem to send these packets at the same time as the java client. But i haven't found any doc to check the order of that packet. (Or maybe it won't be sent at all)

`isGeyser` field is inherited from the original skips code. Probably a little bad. Maybe can check it directly in the `FallbackVerificationHandler`?