### PR TITLE
1.21 Support

### DIFF
--- a/sonar-api/src/main/java/xyz/jonesdev/sonar/api/fallback/protocol/ProtocolVersion.java
+++ b/sonar-api/src/main/java/xyz/jonesdev/sonar/api/fallback/protocol/ProtocolVersion.java
@@ -69,7 +69,8 @@ public enum ProtocolVersion {
   MINECRAFT_1_20(763),
   MINECRAFT_1_20_2(764),
   MINECRAFT_1_20_3(765),
-  MINECRAFT_1_20_5(766);
+  MINECRAFT_1_20_5(766),
+  MINECRAFT_1_21(767);
 
   private final int protocol;
 


### PR DESCRIPTION
This is a draft PR for the support of Minecraft release 1.21.