### PR TITLE
Release 2.0.30

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 group=xyz.jonesdev.sonar
-version=2.0.29
+version=2.0.30
 description=Effective Anti-bot plugin for Velocity, BungeeCord, and Bukkit (1.7-latest)


### PR DESCRIPTION
- Bump capja from 1.0.2 to 1.0.3 [#294](<https://github.com/jonesdevelopment/sonar/pull/294>)
- Don't cache map data to avoid memory issues [#293](<https://github.com/jonesdevelopment/sonar/pull/293>)

(Thanks to @NoltoxGit for reporting)