### PR TITLE
Bump adventure-platform from 4.3.2 to 4.3.3

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 netty = "4.1.110.Final"
 adventure = "4.17.0"
-adventure-platform = "4.3.2"
+adventure-platform = "4.3.3"
 bstats = "3.0.2"
 libby = "2.0.0-SNAPSHOT"
 


### PR DESCRIPTION
- https://github.com/KyoriPowered/adventure-platform/releases/tag/v4.3.3