### PR TITLE
Release 2.1.17

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 group=xyz.jonesdev
-version=2.1.16
+version=2.1.17
 description=A lightweight, effective, and easy-to-use anti-bot plugin for Velocity, BungeeCord, and Bukkit.


### PR DESCRIPTION
- Bump mariadb-java-client from 3.4.1 to 3.5.1
- Bump mysql-connector-j from 9.0.0 to 9.1.0
- Use version name instead of ID for logging