### PR TITLE
Release 2.1.18

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 group=xyz.jonesdev
-version=2.1.17
+version=2.1.18
 description=A lightweight, effective, and easy-to-use anti-bot plugin for Velocity, BungeeCord, and Bukkit.


### PR DESCRIPTION
- Fix crash issue on 1.13-1.13.2
- Downgrade mysql-connector-j to 9.0.0

This is a hotfix release that fixes the MySQL driver not loading correctly and 1.13-1.13.2 clients crashing when joining the server.

Massive thanks to the sponsors of Sonar who help keep this project running: @Hydoxl