### PR TITLE
Release 2.1.22

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 group=xyz.jonesdev
-version=2.1.21
+version=2.1.22
 description=A lightweight, effective, and easy-to-use anti-bot plugin for Velocity, BungeeCord, and Bukkit.


### PR DESCRIPTION
- Use full registries to fix compatibility [#429](<https://github.com/jonesdevelopment/sonar/pull/429>)
- Downgrade mariadb-java-client to 3.4.1
- Fix invalid block state ids for 1.21.4

This release aims to fix some compatibility issues with certain mods and clients. Please note that it is impossible for Sonar to simply "fix" broken packets sent by any mod or client.

Thanks to @FallenCrystal for helping me implement the new registries. Check our [her repository](<https://github.com/FallenCrystal/NBTGenerator>) if you want to learn more about how we've implemented the new registries.

Massive thanks to the sponsors of Sonar who help keep this project running: @Hydoxl