### PR TITLE
Bump version from 2.1.24 to 2.1.25

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 group=xyz.jonesdev
-version=2.1.24
+version=2.1.25
 description=A lightweight, effective, and easy-to-use anti-bot plugin for Velocity, BungeeCord, and Bukkit.


### PR DESCRIPTION
- Fix incompatibility with BungeeCord build 1909+

If you're still using BungeeCord or a fork of it, consider upgrading to Velocity if you can.
https://velocitypowered.com/

Massive thanks to the sponsors of Sonar who help keep this project running: @Hydoxl