### PR TITLE
Release 2.1.28

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 group=xyz.jonesdev
-version=2.1.27
+version=2.1.28
 description=A lightweight, effective, and easy-to-use anti-bot plugin for Velocity, BungeeCord, and Bukkit.


### PR DESCRIPTION
This feature update adds support for Minecraft 1.21.5 and a minor fix for carpet fake players.

- Minecraft 1.21.5 Support [#457](<https://github.com/jonesdevelopment/sonar/pull/457>)
- Skip Carpet fake players ([retrooper/packetevents#1171](<https://github.com/retrooper/packetevents/pull/1171>))
- Various minor optimizations in the verification handling

Special thanks to @FallenCrystal for her massive help in [#459](<https://github.com/jonesdevelopment/sonar/pull/459>)!

Massive thanks to the sponsors of Sonar who help keep this project running: @Hydoxl