### PR TITLE
Release 2.1.30

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 group=xyz.jonesdev
-version=2.1.29
+version=2.1.30
 description=A lightweight, effective, and easy-to-use anti-bot plugin for Velocity, BungeeCord, and Bukkit.


### PR DESCRIPTION
This update fixes several issues with mods, especially Sodium, not being able to enter the server. Additionally, the adventure component library has been updated from 4.20.0 to 4.21.0 and several possible minor memory leaks in the Bukkit packet handling have been fixed.

- Bump adventure from 4.20.0 to 4.21.0
- Fix Sodium world loading taking too long [#471](<https://github.com/jonesdevelopment/sonar/pull/471>)
- Fix potential memory leaks on Bukkit [#463](<https://github.com/jonesdevelopment/sonar/pull/463>)

Massive thanks to the sponsors of Sonar who help keep this project running: [Hydoxl](<https://github.com/Hydoxl>)