### PR TITLE
Release 2.1.31

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 group=xyz.jonesdev
-version=2.1.30
+version=2.1.31
 description=A lightweight, effective, and easy-to-use anti-bot plugin for Velocity, BungeeCord, and Bukkit.


### PR DESCRIPTION
This updates fixes several issues with Minecraft 1.21.5 components (related to [adventure 4.21.0](<https://github.com/KyoriPowered/adventure/releases/tag/v4.21.0>)) on BungeeCord and Bukkit. Some other dependencies have been updated as well.

Massive thanks to the sponsors of Sonar who help keep this project running: @Hydoxl