### PR TITLE
Release 2.1.32

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 group=xyz.jonesdev
-version=2.1.31
+version=2.1.32
 description=A lightweight, effective, and easy-to-use anti-bot plugin for Velocity, BungeeCord, and Bukkit.


### PR DESCRIPTION
This update fixes a false positive with older cosmetics mods and clients. Additionally, Geyser (Bedrock) players are now skipped by default, and an old check has been removed as it was deemed unnecessary.
Official support for Geyser will no longer be provided, but you can still use the feature if you like.

Massive thanks to the sponsors of Sonar who help keep this project running: @Hydoxl