### PR TITLE
Release 2.1.34

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 group=xyz.jonesdev
-version=2.1.33
+version=2.1.34
 description=A lightweight, effective, and easy-to-use anti-bot plugin for Velocity, BungeeCord, and Bukkit.


### PR DESCRIPTION
This update adds support for Minecraft 1.21.7 and missing 1.21.6 implementations on Bukkit servers.

Massive thanks to the sponsors of Sonar who help keep this project running: @Hydoxl