### PR TITLE
Release 2.1.35

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 group=xyz.jonesdev
-version=2.1.34
+version=2.1.35
 description=A lightweight, effective, and easy-to-use anti-bot plugin for Velocity, BungeeCord, and Bukkit.


### PR DESCRIPTION
This update fixes a false positive caused by a Minecraft bug. Additionally, admins can now show the number of CAPTCHA attempts left in the `verification.captcha.incorrect` message using the placeholder `<attempts-left>`.

**Full Changelog**
- Remove locale regex check due to a Minecraft bug
- Add missing translations for the new feature
- Make incorrect captcha message contain attempts left
- Allow "fell through" check to be skipped by a CAPTCHA

Massive thanks to the sponsors of Sonar who help keep this project running: @Hydoxl