### PR TITLE
More strict client tick check for 1.21.2+ clients

### DIFF
--- a/common/src/main/java/xyz/jonesdev/sonar/common/fallback/verification/FallbackGravityHandler.java
+++ b/common/src/main/java/xyz/jonesdev/sonar/common/fallback/verification/FallbackGravityHandler.java
@@ -161,7 +161,7 @@ public final class FallbackGravityHandler extends FallbackVerificationHandler {
       if (!expectClientTick) {
         // Is it impossible for the client to not move during the gravity check?
         if (++tickWithoutMove >= 20) {
-          this.fail("expected position but got client tick end.");
+          fail("expected position but got client tick end.");
         }
       } else {
         tickWithoutMove = 0;
@@ -175,7 +175,7 @@ public final class FallbackGravityHandler extends FallbackVerificationHandler {
       return;
     }
     if (expectClientTick) {
-      this.failOrShowCaptcha("expected client tick end but got position.");
+      failOrShowCaptcha("expected client tick end but got position.");
     } else {
       expectClientTick = true;
     }

--- a/common/src/main/java/xyz/jonesdev/sonar/common/fallback/verification/FallbackGravityHandler.java
+++ b/common/src/main/java/xyz/jonesdev/sonar/common/fallback/verification/FallbackGravityHandler.java
@@ -93,9 +93,9 @@ public final class FallbackGravityHandler extends FallbackVerificationHandler {
 
   private final FallbackPreJoinHandler preJoinHandler;
   private final boolean enableGravityCheck, enableCollisionsCheck;
-  private boolean teleported, canFall, checkMovement;
+  private boolean teleported, canFall, checkMovement, expectClientTick, expectTeleportPosRot;
   private double y, deltaY, blockHeight;
-  private int movementTick, clientTick, expectedTeleportId = FIRST_TELEPORT_ID;
+  private int movementTick, tickWithoutMove, expectedTeleportId = FIRST_TELEPORT_ID;
   private SetPlayerPositionRotationPacket lastPositionPacket;
 
   @Override
@@ -105,8 +105,14 @@ public final class FallbackGravityHandler extends FallbackVerificationHandler {
       final SetPlayerPositionRotationPacket position = (SetPlayerPositionRotationPacket) packet;
       if (teleported) {
         handleMovement(position.getX(), position.getY(), position.getZ(), position.isOnGround(), true);
-      } else if (user.getProtocolVersion().greaterThanOrEquals(ProtocolVersion.MINECRAFT_1_21_2)) {
+      } else if (user.getProtocolVersion() == ProtocolVersion.MINECRAFT_1_21_2) {
         lastPositionPacket = position;
+        return;
+      }
+      if (expectTeleportPosRot) {
+        expectTeleportPosRot = false;
+      } else {
+        checkClientTick();
       }
     } else if (packet instanceof SetPlayerPositionPacket) {
       // Make sure the player has teleported before checking for position packets
@@ -114,6 +120,7 @@ public final class FallbackGravityHandler extends FallbackVerificationHandler {
         final SetPlayerPositionPacket position = (SetPlayerPositionPacket) packet;
         handleMovement(position.getX(), position.getY(), position.getZ(), position.isOnGround(), false);
       }
+      checkClientTick();
     } else if (packet instanceof ConfirmTeleportationPacket) {
       final ConfirmTeleportationPacket confirmTeleport = (ConfirmTeleportationPacket) packet;
 
@@ -123,28 +130,54 @@ public final class FallbackGravityHandler extends FallbackVerificationHandler {
       checkState(confirmTeleport.getTeleportId() == expectedTeleportId,
         "expected TP ID " + expectedTeleportId + ", but got " + confirmTeleport.getTeleportId());
 
+      final boolean sendPosRotBefore = user.getProtocolVersion() == ProtocolVersion.MINECRAFT_1_21_2;
+      checkState(sendPosRotBefore ? lastPositionPacket != null : !expectTeleportPosRot,
+        "expected position rotation but got teleport confirm.");
+      if (!sendPosRotBefore) {
+        expectTeleportPosRot = true;
+      }
+
       // The first teleport ID is not useful for us in this context, skip it
       if (expectedTeleportId == FIRST_TELEPORT_ID) {
-        lastPositionPacket = null;
         expectedTeleportId = SECOND_TELEPORT_ID;
       } else {
         // Enable the movement checks
         teleported = true;
 
-        if (user.getProtocolVersion().greaterThanOrEquals(ProtocolVersion.MINECRAFT_1_21_2)) {
-          checkState(lastPositionPacket != null, "excepted position rotation but got teleport confirm.");
+        if (sendPosRotBefore) {
           handleMovement(
             lastPositionPacket.getX(), lastPositionPacket.getY(), lastPositionPacket.getZ(),
             lastPositionPacket.isOnGround(), true);
         }
       }
+      lastPositionPacket = null;
     } else if (packet instanceof ClientInformationPacket
       || packet instanceof PluginMessagePacket) {
       // Pass these packets back to the login handler
       // TODO: recode this
       preJoinHandler.handle(packet);
     } else if (packet instanceof ClientTickEndPacket) {
-      clientTick++;
+      lastPositionPacket = null;
+      if (!expectClientTick) {
+        // Is it impossible for the client to not move during the gravity check?
+        if (++tickWithoutMove >= 20) {
+          this.fail("expected position but got client tick end.");
+        }
+      } else {
+        tickWithoutMove = 0;
+        expectClientTick = false;
+      }
+    }
+  }
+
+  private void checkClientTick() {
+    if (user.getProtocolVersion().lessThan(ProtocolVersion.MINECRAFT_1_21_2)) {
+      return;
+    }
+    if (expectClientTick) {
+      this.failOrShowCaptcha("expected client tick end but got position.");
+    } else {
+      expectClientTick = true;
     }
   }
 
@@ -206,11 +239,6 @@ public final class FallbackGravityHandler extends FallbackVerificationHandler {
     // This should not happen unless the max movement tick is configured to a high number.
     checkState(Math.abs(Math.abs(x) - BLOCKS_PER_ROW) < BLOCKS_PER_ROW, "illegal x offset: " + x);
     checkState(Math.abs(Math.abs(z) - BLOCKS_PER_ROW) < BLOCKS_PER_ROW, "illegal z offset: " + z);
-
-    // Check if the client is ticking correctly
-    if (user.getProtocolVersion().greaterThanOrEquals(ProtocolVersion.MINECRAFT_1_21_2)) {
-      checkState(clientTick >= movementTick, "invalid ticking: " + clientTick + "/" + movementTick);
-    }
 
     if (!onGround) {
       // The deltaY is 0 whenever the player sends their first position packet.

--- a/common/src/main/java/xyz/jonesdev/sonar/common/fallback/verification/FallbackGravityHandler.java
+++ b/common/src/main/java/xyz/jonesdev/sonar/common/fallback/verification/FallbackGravityHandler.java
@@ -105,7 +105,7 @@ public final class FallbackGravityHandler extends FallbackVerificationHandler {
       final SetPlayerPositionRotationPacket position = (SetPlayerPositionRotationPacket) packet;
       if (teleported) {
         handleMovement(position.getX(), position.getY(), position.getZ(), position.isOnGround(), true);
-      } else if (user.getProtocolVersion() == ProtocolVersion.MINECRAFT_1_21_2) {
+      } else if (user.getProtocolVersion().equals(ProtocolVersion.MINECRAFT_1_21_2)) {
         lastPositionPacket = position;
         return;
       }
@@ -130,7 +130,7 @@ public final class FallbackGravityHandler extends FallbackVerificationHandler {
       checkState(confirmTeleport.getTeleportId() == expectedTeleportId,
         "expected TP ID " + expectedTeleportId + ", but got " + confirmTeleport.getTeleportId());
 
-      final boolean sendPosRotBefore = user.getProtocolVersion() == ProtocolVersion.MINECRAFT_1_21_2;
+      final boolean sendPosRotBefore = user.getProtocolVersion().equals(ProtocolVersion.MINECRAFT_1_21_2);
       checkState(sendPosRotBefore ? lastPositionPacket != null : !expectTeleportPosRot,
         "expected position rotation but got teleport confirm.");
       if (!sendPosRotBefore) {

--- a/common/src/main/java/xyz/jonesdev/sonar/common/fallback/verification/FallbackGravityHandler.java
+++ b/common/src/main/java/xyz/jonesdev/sonar/common/fallback/verification/FallbackGravityHandler.java
@@ -179,6 +179,7 @@ public final class FallbackGravityHandler extends FallbackVerificationHandler {
     } else {
       expectClientTick = true;
     }
+    tickWithoutMove = 0; // lag may cause some problems :(
   }
 
   private void markSuccess() {

--- a/common/src/main/java/xyz/jonesdev/sonar/common/fallback/verification/FallbackVehicleHandler.java
+++ b/common/src/main/java/xyz/jonesdev/sonar/common/fallback/verification/FallbackVehicleHandler.java
@@ -19,7 +19,6 @@ package xyz.jonesdev.sonar.common.fallback.verification;
 
 import lombok.RequiredArgsConstructor;
 import org.jetbrains.annotations.NotNull;
-import org.jetbrains.annotations.Nullable;
 import xyz.jonesdev.sonar.api.Sonar;
 import xyz.jonesdev.sonar.api.fallback.FallbackUser;
 import xyz.jonesdev.sonar.api.fallback.protocol.ProtocolVersion;
@@ -41,9 +40,8 @@ public final class FallbackVehicleHandler extends FallbackVerificationHandler {
   private State state = State.WAITING;
   private State nextState;
   private int expectedKeepAliveId;
-  private int checkedRound;
+  private int rotations, inputs, paddles, vehicleMoves;
   private double boatMotion, boatY = IN_AIR_Y_POSITION;
-  private @Nullable ExpectVehiclePacket expectVehiclePacket = null;
 
   @RequiredArgsConstructor
   private enum State {
@@ -54,18 +52,6 @@ public final class FallbackVehicleHandler extends FallbackVerificationHandler {
     IN_AIR_AFTER_MINECART(false);
 
     private final boolean inVehicle;
-  }
-
-  private enum ExpectVehiclePacket {
-    PADDLE_BOAT,
-    PLAYER_ROTATION,
-    PLAYER_INPUT,
-    VEHICLE_MOVE,
-    CLIENT_TICK_END;
-
-    public @NotNull String formattedName() {
-      return name().toLowerCase().replace('_', ' ');
-    }
   }
 
   @Override
@@ -82,25 +68,60 @@ public final class FallbackVehicleHandler extends FallbackVerificationHandler {
       state = nextState;
       nextState = null;
       waitingForStateChange = false;
-      if (!state.inVehicle) {
-        expectVehiclePacket = null;
+    } else if (!waitingForStateChange) {
+      if (packet instanceof PaddleBoatPacket) {
+        if (state == State.IN_BOAT) {
+          paddles++;
+        }
+      } else if (packet instanceof VehicleMovePacket) {
+        if (state == State.IN_BOAT) {
+          final VehicleMovePacket vehicleMove = (VehicleMovePacket) packet;
+          // Check the Y position of the vehicle
+          checkState(vehicleMove.getY() <= IN_AIR_Y_POSITION, "bad vehicle y: " + vehicleMove.getY());
+
+          // Check the gravity of the vehicle
+          final double lastBoatMotion = boatMotion;
+          final double lastBoatY = boatY;
+          boatY = vehicleMove.getY();
+          boatMotion = boatY - lastBoatY;
+          final double predicted = lastBoatMotion - 0.03999999910593033D;
+          final double difference = Math.abs(boatMotion - predicted);
+          // Check if the difference between the predicted and actual motion is too large
+          checkState(difference < 1e-7, "bad vehicle gravity: " + predicted + "/" + boatMotion);
+
+          vehicleMoves++;
+        }
+      } else if (packet instanceof SetPlayerRotationPacket) {
+        if (state.inVehicle) {
+          rotations++;
+
+          // 1.21.2+ do not send PlayerInput packets when inside a vehicle.
+          // Handle it after SetPlayerRotationPacket to simulate vanilla behavior.
+          if (user.getProtocolVersion().greaterThanOrEquals(ProtocolVersion.MINECRAFT_1_21_2)) {
+            handlePlayerInput();
+          }
+        }
+      } else if (packet instanceof PlayerInputPacket) {
+        // 1.21.2+ send PlayerInput packets when the player starts sprinting, sneaking, etc.
+        if (state.inVehicle && user.getProtocolVersion().lessThan(ProtocolVersion.MINECRAFT_1_21_2)) {
+          final PlayerInputPacket playerInput = (PlayerInputPacket) packet;
+
+          // Check if the player is sending invalid vehicle speed values
+          final float forward = Math.abs(playerInput.getForward());
+          final float sideways = Math.abs(playerInput.getSideways());
+          final float maxVehicleSpeed = /*user.isGeyser() ? 1 :*/ 0.98f;
+          checkState(forward <= maxVehicleSpeed, "illegal speed (f): " + forward);
+          checkState(sideways <= maxVehicleSpeed, "illegal speed (s): " + sideways);
+
+          handlePlayerInput();
+        }
+      } else if (packet instanceof SetPlayerPositionRotationPacket) {
+        final SetPlayerPositionRotationPacket posRot = (SetPlayerPositionRotationPacket) packet;
+        handleMovement(posRot.getY(), posRot.isOnGround());
+      } else if (packet instanceof SetPlayerPositionPacket) {
+        final SetPlayerPositionPacket position = (SetPlayerPositionPacket) packet;
+        handleMovement(position.getY(), position.isOnGround());
       }
-    } else if (packet instanceof PaddleBoatPacket) {
-      onPaddleBoat((PaddleBoatPacket) packet);
-    } else if (packet instanceof VehicleMovePacket) {
-      onVehicleMove((VehicleMovePacket) packet);
-    } else if (packet instanceof SetPlayerRotationPacket) {
-      onPlayerRotation((SetPlayerRotationPacket) packet);
-    } else if (packet instanceof PlayerInputPacket) {
-      onPlayerInput((PlayerInputPacket) packet);
-    } else if (packet instanceof ClientTickEndPacket) {
-      onClientTickEnd((ClientTickEndPacket) packet);
-    } else if (packet instanceof SetPlayerPositionRotationPacket) {
-      final SetPlayerPositionRotationPacket posRot = (SetPlayerPositionRotationPacket) packet;
-      handleMovement(posRot.getY(), posRot.isOnGround());
-    } else if (packet instanceof SetPlayerPositionPacket) {
-      final SetPlayerPositionPacket position = (SetPlayerPositionPacket) packet;
-      handleMovement(position.getY(), position.isOnGround());
     }
   }
 
@@ -108,14 +129,13 @@ public final class FallbackVehicleHandler extends FallbackVerificationHandler {
     user.delayedWrite(nextState == State.IN_BOAT ? SPAWN_BOAT_ENTITY : SPAWN_MINECART_ENTITY);
     user.delayedWrite(SET_VEHICLE_PASSENGERS);
     prepareForNextState(nextState);
-    expectVehiclePacket = isClientMovingVehicle() ? ExpectVehiclePacket.PADDLE_BOAT : ExpectVehiclePacket.PLAYER_ROTATION;
   }
 
   private void prepareForNextState(final @NotNull State nextState) {
     this.nextState = nextState;
     waitingForStateChange = true;
     expectedKeepAliveId = RANDOM.nextInt();
-    checkedRound = 0;
+    rotations = inputs = paddles = vehicleMoves = 0;
     user.delayedWrite(new KeepAlivePacket(expectedKeepAliveId));
     user.channel().flush();
   }
@@ -131,12 +151,9 @@ public final class FallbackVehicleHandler extends FallbackVerificationHandler {
 
   private void handleMovement(final double y, final boolean isOnGround) {
     // Make sure we're currently expecting movement
-    if (state == State.WAITING) {
+    if (state.inVehicle || state == State.WAITING) {
       return;
     }
-    checkState(!state.inVehicle && !waitingForStateChange,
-      "sending move packet while in vehicle");
-    expectVehiclePacket = null;
 
     // Make sure the ground state and y position are correct
     checkState(y <= boatY, "invalid y: " + y);
@@ -149,99 +166,31 @@ public final class FallbackVehicleHandler extends FallbackVerificationHandler {
     }
   }
 
-  private void onPaddleBoat(final @NotNull PaddleBoatPacket packet) {
-    checkState(isClientMovingVehicle(), "received unexpected paddle boat");
-    checkPacketOrder(ExpectVehiclePacket.PADDLE_BOAT);
-    expectVehiclePacket = ExpectVehiclePacket.PLAYER_ROTATION;
-  }
-
-  private void onPlayerRotation(final @NotNull SetPlayerRotationPacket packet) {
-    checkPacketOrder(ExpectVehiclePacket.PLAYER_ROTATION);
-
-    // Check yaw/pitch?
-
-    if (user.getProtocolVersion().lessThan(ProtocolVersion.MINECRAFT_1_21_2)) {
-      expectVehiclePacket = ExpectVehiclePacket.PLAYER_INPUT;
-    } else if (isClientMovingVehicle()) {
-      expectVehiclePacket = ExpectVehiclePacket.VEHICLE_MOVE;
-    } else {
-      expectVehiclePacket = ExpectVehiclePacket.CLIENT_TICK_END;
+  private void handlePlayerInput() {
+    // 1.8 and below do not have PaddleBoat packets, so we simply exempt them from the PaddleBoat check.
+    // Clients also don't send PaddleBoat & VehicleMovePacket packets while riding minecarts.
+    if (user.getProtocolVersion().lessThan(ProtocolVersion.MINECRAFT_1_9) || state == State.IN_MINECART) {
+      paddles++;
+      vehicleMoves++;
     }
-  }
 
-  private void onPlayerInput(final @NotNull PlayerInputPacket packet) {
-    // 1.21.2+ send PlayerInput packets when the player starts sprinting, sneaking, etc.
-    if (user.getProtocolVersion().greaterThanOrEquals(ProtocolVersion.MINECRAFT_1_21_2)) {
-      return;
-    }
-    checkPacketOrder(ExpectVehiclePacket.PLAYER_INPUT);
+    // Check for packet order
+    checkState(rotations >= inputs,
+      "illegal packet order; i/r " + inputs + "/" + rotations);
+    checkState(paddles >= inputs,
+      "illegal packet order; i/p " + inputs + "/" + paddles);
+    checkState(vehicleMoves >= inputs,
+      "illegal packet order; i/v " + inputs + "/" + vehicleMoves);
 
-    // Check if the player is sending invalid vehicle speed values
-    final float forward = Math.abs(packet.getForward());
-    final float sideways = Math.abs(packet.getSideways());
-    final float maxVehicleSpeed = /*user.isGeyser() ? 1 :*/ 0.98f;
-    checkState(forward <= maxVehicleSpeed, "illegal speed (f): " + forward);
-    checkState(sideways <= maxVehicleSpeed, "illegal speed (s): " + sideways);
+    inputs++;
 
-    if (isClientMovingVehicle()) {
-      expectVehiclePacket = ExpectVehiclePacket.VEHICLE_MOVE;
-    } else {
-      finishRound();
-    }
-  }
-
-  private void onVehicleMove(final @NotNull VehicleMovePacket packet) {
-    checkState(isClientMovingVehicle(), "received unexpected vehicle move");
-    checkPacketOrder(ExpectVehiclePacket.VEHICLE_MOVE);
-
-    // Check the Y position of the vehicle
-    checkState(packet.getY() <= IN_AIR_Y_POSITION, "bad vehicle y: " + packet.getY());
-
-    // Check the gravity of the vehicle
-    final double lastBoatMotion = boatMotion;
-    final double lastBoatY = boatY;
-    boatY = packet.getY();
-    boatMotion = boatY - lastBoatY;
-    final double predicted = lastBoatMotion - 0.03999999910593033D;
-    final double difference = Math.abs(boatMotion - predicted);
-    // Check if the difference between the predicted and actual motion is too large
-    checkState(difference < 1e-7, "bad vehicle gravity: " + predicted + "/" + boatMotion);
-
-    if (user.getProtocolVersion().lessThan(ProtocolVersion.MINECRAFT_1_21_2)) {
-      finishRound();
-    } else {
-      expectVehiclePacket = ExpectVehiclePacket.CLIENT_TICK_END;
-    }
-  }
-
-  private void onClientTickEnd(final @NotNull ClientTickEndPacket packet) {
-    if (expectVehiclePacket == ExpectVehiclePacket.CLIENT_TICK_END) {
-      finishRound();
-    } else if (!waitingForStateChange && state.inVehicle) { // Client can send end tick while not in vehicle
-      checkPacketOrder(ExpectVehiclePacket.CLIENT_TICK_END); // fail
-    }
-  }
-
-  private void finishRound() {
+    // Check if we've received more than the minimum number of packets
     final int minimumPackets = Sonar.get0().getConfig().getVerification().getVehicle().getMinimumPackets();
-    if (++checkedRound > minimumPackets) {
+    if (inputs > minimumPackets && rotations > minimumPackets
+      && paddles > minimumPackets && vehicleMoves > minimumPackets) {
       // Move on to the next stage
-      expectVehiclePacket = null;
       user.delayedWrite(REMOVE_VEHICLE);
       prepareForNextState(state == State.IN_BOAT ? State.IN_AIR_AFTER_BOAT : State.IN_AIR_AFTER_MINECART);
-    } else {
-      expectVehiclePacket = isClientMovingVehicle() ? ExpectVehiclePacket.PADDLE_BOAT : ExpectVehiclePacket.PLAYER_ROTATION;
     }
-  }
-
-  private boolean isClientMovingVehicle() {
-    return (waitingForStateChange && nextState.inVehicle ? nextState : state) == State.IN_BOAT
-      && user.getProtocolVersion().greaterThan(ProtocolVersion.MINECRAFT_1_8);
-  }
-
-  private void checkPacketOrder(final @NotNull ExpectVehiclePacket current) {
-    checkState(expectVehiclePacket == current, expectVehiclePacket == null
-      ? "sending vehicle packet while not in vehicle (" + current.formattedName() + ")"
-      : "expected " + expectVehiclePacket.formattedName() + " but got " + current.formattedName());
   }
 }

--- a/common/src/main/java/xyz/jonesdev/sonar/common/fallback/verification/FallbackVehicleHandler.java
+++ b/common/src/main/java/xyz/jonesdev/sonar/common/fallback/verification/FallbackVehicleHandler.java
@@ -19,6 +19,7 @@ package xyz.jonesdev.sonar.common.fallback.verification;
 
 import lombok.RequiredArgsConstructor;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import xyz.jonesdev.sonar.api.Sonar;
 import xyz.jonesdev.sonar.api.fallback.FallbackUser;
 import xyz.jonesdev.sonar.api.fallback.protocol.ProtocolVersion;
@@ -40,8 +41,9 @@ public final class FallbackVehicleHandler extends FallbackVerificationHandler {
   private State state = State.WAITING;
   private State nextState;
   private int expectedKeepAliveId;
-  private int rotations, inputs, paddles, vehicleMoves;
+  private int checkedRound;
   private double boatMotion, boatY = IN_AIR_Y_POSITION;
+  private @Nullable ExpectVehiclePacket expectVehiclePacket = null;
 
   @RequiredArgsConstructor
   private enum State {
@@ -52,6 +54,18 @@ public final class FallbackVehicleHandler extends FallbackVerificationHandler {
     IN_AIR_AFTER_MINECART(false);
 
     private final boolean inVehicle;
+  }
+
+  private enum ExpectVehiclePacket {
+    PADDLE_BOAT,
+    PLAYER_ROTATION,
+    PLAYER_INPUT,
+    VEHICLE_MOVE,
+    CLIENT_TICK_END;
+
+    public @NotNull String formattedName() {
+      return name().toLowerCase().replace('_', ' ');
+    }
   }
 
   @Override
@@ -68,60 +82,25 @@ public final class FallbackVehicleHandler extends FallbackVerificationHandler {
       state = nextState;
       nextState = null;
       waitingForStateChange = false;
-    } else if (!waitingForStateChange) {
-      if (packet instanceof PaddleBoatPacket) {
-        if (state == State.IN_BOAT) {
-          paddles++;
-        }
-      } else if (packet instanceof VehicleMovePacket) {
-        if (state == State.IN_BOAT) {
-          final VehicleMovePacket vehicleMove = (VehicleMovePacket) packet;
-          // Check the Y position of the vehicle
-          checkState(vehicleMove.getY() <= IN_AIR_Y_POSITION, "bad vehicle y: " + vehicleMove.getY());
-
-          // Check the gravity of the vehicle
-          final double lastBoatMotion = boatMotion;
-          final double lastBoatY = boatY;
-          boatY = vehicleMove.getY();
-          boatMotion = boatY - lastBoatY;
-          final double predicted = lastBoatMotion - 0.03999999910593033D;
-          final double difference = Math.abs(boatMotion - predicted);
-          // Check if the difference between the predicted and actual motion is too large
-          checkState(difference < 1e-7, "bad vehicle gravity: " + predicted + "/" + boatMotion);
-
-          vehicleMoves++;
-        }
-      } else if (packet instanceof SetPlayerRotationPacket) {
-        if (state.inVehicle) {
-          rotations++;
-
-          // 1.21.2+ do not send PlayerInput packets when inside a vehicle.
-          // Handle it after SetPlayerRotationPacket to simulate vanilla behavior.
-          if (user.getProtocolVersion().greaterThanOrEquals(ProtocolVersion.MINECRAFT_1_21_2)) {
-            handlePlayerInput();
-          }
-        }
-      } else if (packet instanceof PlayerInputPacket) {
-        // 1.21.2+ send PlayerInput packets when the player starts sprinting, sneaking, etc.
-        if (state.inVehicle && user.getProtocolVersion().lessThan(ProtocolVersion.MINECRAFT_1_21_2)) {
-          final PlayerInputPacket playerInput = (PlayerInputPacket) packet;
-
-          // Check if the player is sending invalid vehicle speed values
-          final float forward = Math.abs(playerInput.getForward());
-          final float sideways = Math.abs(playerInput.getSideways());
-          final float maxVehicleSpeed = /*user.isGeyser() ? 1 :*/ 0.98f;
-          checkState(forward <= maxVehicleSpeed, "illegal speed (f): " + forward);
-          checkState(sideways <= maxVehicleSpeed, "illegal speed (s): " + sideways);
-
-          handlePlayerInput();
-        }
-      } else if (packet instanceof SetPlayerPositionRotationPacket) {
-        final SetPlayerPositionRotationPacket posRot = (SetPlayerPositionRotationPacket) packet;
-        handleMovement(posRot.getY(), posRot.isOnGround());
-      } else if (packet instanceof SetPlayerPositionPacket) {
-        final SetPlayerPositionPacket position = (SetPlayerPositionPacket) packet;
-        handleMovement(position.getY(), position.isOnGround());
+      if (!state.inVehicle) {
+        expectVehiclePacket = null;
       }
+    } else if (packet instanceof PaddleBoatPacket) {
+      onPaddleBoat((PaddleBoatPacket) packet);
+    } else if (packet instanceof VehicleMovePacket) {
+      onVehicleMove((VehicleMovePacket) packet);
+    } else if (packet instanceof SetPlayerRotationPacket) {
+      onPlayerRotation((SetPlayerRotationPacket) packet);
+    } else if (packet instanceof PlayerInputPacket) {
+      onPlayerInput((PlayerInputPacket) packet);
+    } else if (packet instanceof ClientTickEndPacket) {
+      onClientTickEnd((ClientTickEndPacket) packet);
+    } else if (packet instanceof SetPlayerPositionRotationPacket) {
+      final SetPlayerPositionRotationPacket posRot = (SetPlayerPositionRotationPacket) packet;
+      handleMovement(posRot.getY(), posRot.isOnGround());
+    } else if (packet instanceof SetPlayerPositionPacket) {
+      final SetPlayerPositionPacket position = (SetPlayerPositionPacket) packet;
+      handleMovement(position.getY(), position.isOnGround());
     }
   }
 
@@ -129,13 +108,14 @@ public final class FallbackVehicleHandler extends FallbackVerificationHandler {
     user.delayedWrite(nextState == State.IN_BOAT ? SPAWN_BOAT_ENTITY : SPAWN_MINECART_ENTITY);
     user.delayedWrite(SET_VEHICLE_PASSENGERS);
     prepareForNextState(nextState);
+    expectVehiclePacket = isClientMovingVehicle() ? ExpectVehiclePacket.PADDLE_BOAT : ExpectVehiclePacket.PLAYER_ROTATION;
   }
 
   private void prepareForNextState(final @NotNull State nextState) {
     this.nextState = nextState;
     waitingForStateChange = true;
     expectedKeepAliveId = RANDOM.nextInt();
-    rotations = inputs = paddles = vehicleMoves = 0;
+    checkedRound = 0;
     user.delayedWrite(new KeepAlivePacket(expectedKeepAliveId));
     user.channel().flush();
   }
@@ -151,9 +131,12 @@ public final class FallbackVehicleHandler extends FallbackVerificationHandler {
 
   private void handleMovement(final double y, final boolean isOnGround) {
     // Make sure we're currently expecting movement
-    if (state.inVehicle || state == State.WAITING) {
+    if (state == State.WAITING) {
       return;
     }
+    checkState(!state.inVehicle && !waitingForStateChange,
+      "sending move packet while in vehicle");
+    expectVehiclePacket = null;
 
     // Make sure the ground state and y position are correct
     checkState(y <= boatY, "invalid y: " + y);
@@ -166,31 +149,99 @@ public final class FallbackVehicleHandler extends FallbackVerificationHandler {
     }
   }
 
-  private void handlePlayerInput() {
-    // 1.8 and below do not have PaddleBoat packets, so we simply exempt them from the PaddleBoat check.
-    // Clients also don't send PaddleBoat & VehicleMovePacket packets while riding minecarts.
-    if (user.getProtocolVersion().lessThan(ProtocolVersion.MINECRAFT_1_9) || state == State.IN_MINECART) {
-      paddles++;
-      vehicleMoves++;
+  private void onPaddleBoat(final @NotNull PaddleBoatPacket packet) {
+    checkState(isClientMovingVehicle(), "received unexpected paddle boat");
+    checkPacketOrder(ExpectVehiclePacket.PADDLE_BOAT);
+    expectVehiclePacket = ExpectVehiclePacket.PLAYER_ROTATION;
+  }
+
+  private void onPlayerRotation(final @NotNull SetPlayerRotationPacket packet) {
+    checkPacketOrder(ExpectVehiclePacket.PLAYER_ROTATION);
+
+    // Check yaw/pitch?
+
+    if (user.getProtocolVersion().lessThan(ProtocolVersion.MINECRAFT_1_21_2)) {
+      expectVehiclePacket = ExpectVehiclePacket.PLAYER_INPUT;
+    } else if (isClientMovingVehicle()) {
+      expectVehiclePacket = ExpectVehiclePacket.VEHICLE_MOVE;
+    } else {
+      expectVehiclePacket = ExpectVehiclePacket.CLIENT_TICK_END;
     }
+  }
 
-    // Check for packet order
-    checkState(rotations >= inputs,
-      "illegal packet order; i/r " + inputs + "/" + rotations);
-    checkState(paddles >= inputs,
-      "illegal packet order; i/p " + inputs + "/" + paddles);
-    checkState(vehicleMoves >= inputs,
-      "illegal packet order; i/v " + inputs + "/" + vehicleMoves);
+  private void onPlayerInput(final @NotNull PlayerInputPacket packet) {
+    // 1.21.2+ send PlayerInput packets when the player starts sprinting, sneaking, etc.
+    if (user.getProtocolVersion().greaterThanOrEquals(ProtocolVersion.MINECRAFT_1_21_2)) {
+      return;
+    }
+    checkPacketOrder(ExpectVehiclePacket.PLAYER_INPUT);
 
-    inputs++;
+    // Check if the player is sending invalid vehicle speed values
+    final float forward = Math.abs(packet.getForward());
+    final float sideways = Math.abs(packet.getSideways());
+    final float maxVehicleSpeed = /*user.isGeyser() ? 1 :*/ 0.98f;
+    checkState(forward <= maxVehicleSpeed, "illegal speed (f): " + forward);
+    checkState(sideways <= maxVehicleSpeed, "illegal speed (s): " + sideways);
 
-    // Check if we've received more than the minimum number of packets
+    if (isClientMovingVehicle()) {
+      expectVehiclePacket = ExpectVehiclePacket.VEHICLE_MOVE;
+    } else {
+      finishRound();
+    }
+  }
+
+  private void onVehicleMove(final @NotNull VehicleMovePacket packet) {
+    checkState(isClientMovingVehicle(), "received unexpected vehicle move");
+    checkPacketOrder(ExpectVehiclePacket.VEHICLE_MOVE);
+
+    // Check the Y position of the vehicle
+    checkState(packet.getY() <= IN_AIR_Y_POSITION, "bad vehicle y: " + packet.getY());
+
+    // Check the gravity of the vehicle
+    final double lastBoatMotion = boatMotion;
+    final double lastBoatY = boatY;
+    boatY = packet.getY();
+    boatMotion = boatY - lastBoatY;
+    final double predicted = lastBoatMotion - 0.03999999910593033D;
+    final double difference = Math.abs(boatMotion - predicted);
+    // Check if the difference between the predicted and actual motion is too large
+    checkState(difference < 1e-7, "bad vehicle gravity: " + predicted + "/" + boatMotion);
+
+    if (user.getProtocolVersion().lessThan(ProtocolVersion.MINECRAFT_1_21_2)) {
+      this.finishRound();
+    } else {
+      expectVehiclePacket = ExpectVehiclePacket.CLIENT_TICK_END;
+    }
+  }
+
+  private void onClientTickEnd(final @NotNull ClientTickEndPacket packet) {
+    if (expectVehiclePacket == ExpectVehiclePacket.CLIENT_TICK_END) {
+      finishRound();
+    } else if (!waitingForStateChange && state.inVehicle) { // Client can send end tick while not in vehicle
+      checkPacketOrder(ExpectVehiclePacket.CLIENT_TICK_END); // fail
+    }
+  }
+
+  private void finishRound() {
     final int minimumPackets = Sonar.get0().getConfig().getVerification().getVehicle().getMinimumPackets();
-    if (inputs > minimumPackets && rotations > minimumPackets
-      && paddles > minimumPackets && vehicleMoves > minimumPackets) {
+    if (++checkedRound > minimumPackets) {
       // Move on to the next stage
+      expectVehiclePacket = null;
       user.delayedWrite(REMOVE_VEHICLE);
       prepareForNextState(state == State.IN_BOAT ? State.IN_AIR_AFTER_BOAT : State.IN_AIR_AFTER_MINECART);
+    } else {
+      expectVehiclePacket = isClientMovingVehicle() ? ExpectVehiclePacket.PADDLE_BOAT : ExpectVehiclePacket.PLAYER_ROTATION;
     }
+  }
+
+  private boolean isClientMovingVehicle() {
+    return (waitingForStateChange && nextState.inVehicle ? nextState : state) == State.IN_BOAT
+      && user.getProtocolVersion().greaterThan(ProtocolVersion.MINECRAFT_1_8);
+  }
+
+  private void checkPacketOrder(final @NotNull ExpectVehiclePacket current) {
+    checkState(expectVehiclePacket == current, expectVehiclePacket == null
+      ? "sending vehicle packet while not in vehicle (" + current.formattedName() + ")"
+      : "expected " + expectVehiclePacket.formattedName() + " but got " + current.formattedName());
   }
 }

--- a/common/src/main/java/xyz/jonesdev/sonar/common/fallback/verification/FallbackVehicleHandler.java
+++ b/common/src/main/java/xyz/jonesdev/sonar/common/fallback/verification/FallbackVehicleHandler.java
@@ -208,7 +208,7 @@ public final class FallbackVehicleHandler extends FallbackVerificationHandler {
     checkState(difference < 1e-7, "bad vehicle gravity: " + predicted + "/" + boatMotion);
 
     if (user.getProtocolVersion().lessThan(ProtocolVersion.MINECRAFT_1_21_2)) {
-      this.finishRound();
+      finishRound();
     } else {
       expectVehiclePacket = ExpectVehiclePacket.CLIENT_TICK_END;
     }


### PR DESCRIPTION
- Attempting to fix the logically incorrect teleport handling for 1.21.4+. *Only version 1.21.2/3 of the client will send position rotation before sending teleport confirm.*
- For 1.21.2+ clients, each movement packet will now require a `client tick end` packet. *Apart from the extra `position rotation` packet sent by the client due to accepting teleport.*
- Refactored the vehicle check to implement stricter vehicle packet order verification, including checking `client tick end` packet.
- This PR is likely to break the client-side of VV (such as ViaFabric, ViaProxy). But it has never worked properly on sonar.

Tested on:
- 1.21.8
- 1.21.2
- 1.21.1

More tests may be needed.