### PR TITLE
Release 2.1.36

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 group=xyz.jonesdev
-version=2.1.35
+version=2.1.36
 description=A lightweight, effective, and easy-to-use anti-bot plugin for Velocity, BungeeCord, and Bukkit.


### PR DESCRIPTION
This update fixes an issue where the online players per IP check would not work at all. Additionally, a few dependencies have been updated and 1.21.8 is now fully supported on Bukkit.

**Full Changelog**
- Fix max online per IP check
- 1.21.8 Support (server-only)
- Update `velocity-proxy` dependency
- Bump net.kyori.indra.git from 3.1.3 to 3.2.0
- Bump com.diffplug.spotless from 7.1.0 to 7.2.1