### PR TITLE
Support external anti-bot checks

### DIFF
--- a/common/src/main/java/xyz/jonesdev/sonar/common/fallback/netty/FallbackInjectedChannelInitializer.java
+++ b/common/src/main/java/xyz/jonesdev/sonar/common/fallback/netty/FallbackInjectedChannelInitializer.java
@@ -53,6 +53,9 @@ public final class FallbackInjectedChannelInitializer extends ChannelInitializer
 
   @Override
   protected void initChannel(final Channel channel) throws Exception {
+    if (channel == null || !channel.isActive()) {
+      return;
+    }
     // Invoke the original method
     try {
       INIT_CHANNEL_METHOD.invokeExact(originalChannelInitializer, channel);


### PR DESCRIPTION
Before trying to initialize or inject into a channel, check if it was closed by an anti-bot running on the Velocity proxy. This prevent throwing exceptions when the channel was not initialized.