### PR TITLE
Release 2.1.41

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 group=xyz.jonesdev
-version=2.1.40
+version=2.1.41
 description=A lightweight, effective, and easy-to-use anti-bot plugin for Velocity, BungeeCord, and Bukkit.


### PR DESCRIPTION
This updates fixes minor incompatibilities with some Velocity forks. In addition, some other minor bugs and inconsistencies have been resolved.

**Full Changelog**
- Don't invoke initChannel if the channel is closed
- Disable max-online-per-ip if it's 0 or negative
- Fix filled_map item type id on 1.21.9+

Massive thanks to the sponsors of Sonar who help keep this project running: @Hydoxl

> ### Notice about Sonar 3.0
> 
> If you are interested in Sonar 3.0, please check out https://sonar.top/. You can read more about what sets Sonar 3.0 apart from Sonar 2.0 here: https://docs.sonar.top/faq. If you want more robust protection, better performance, and awesome new features, check out Sonar 3.0!