### PR TITLE
Release 2.1.44

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 group=xyz.jonesdev
-version=2.1.43
+version=2.1.44
 description=A lightweight, effective, and easy-to-use anti-bot plugin for Velocity, BungeeCord, and Bukkit.


### PR DESCRIPTION
This update fixes an incompatibility with EaglerCraftX-supporting servers. Additionally, commands now work properly on Paper again and several database connectivity problems should be fixed.

From this version on, Paper 1.21+ servers require a different plugin JAR file, `Sonar-Paper.jar`.

**Full Changelog**
- Always skip EaglerCraft players
- Fix `connection has already been closed` [#544](<https://github.com/jonesdevelopment/sonar/pull/544>)
- Add Paper platform [#541](<https://github.com/jonesdevelopment/sonar/pull/541>)
- Remove mentions of nonexistent tests in dependencies
- Make LibraryLoader use correct MiniMessage versions