### PR TITLE
Release 2.1.46

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 group=xyz.jonesdev
-version=2.1.45
+version=2.1.46
 description=A lightweight, effective, and easy-to-use anti-bot plugin for Velocity, BungeeCord, and Bukkit.


### PR DESCRIPTION
This version implements support for Minecraft 26.1. In addition, a new debugging flag `sonar.log-netty-exceptions` was added to enable better bug reporting.

Thanks to @FallenCrystal for helping with this update.