### PR TITLE
Fix Turkish subcommand formatting

### DIFF
--- a/common/src/main/resources/assets/messages/tr.yml
+++ b/common/src/main/resources/assets/messages/tr.yml
@@ -56,7 +56,7 @@ commands:
       - <white><click:open_url:'https://sonar.top/discord/'><hover:show_text:'(Discord\'u açmak için tıklayın)'>Discord üzerinden bir bilet açın </hover></click><click:open_url:'https://github.com/jonesdevelopment/sonar/issues'><hover:show_text:'(GitHub\'ı açmak için tıklayın)'>veya GitHub üzerinde yeni bir sorun açın.
       - ''
     # Ana komutu çalıştırırken gösterilen alt komutların listesi için biçimlendirme
-    subcommands: '<suggest-subcommand><hover:show_text:''<gray>Sadece oyuncular: </gray><only-players><br><gray>Konsol gerekli: </gray><only-console><br><gray>İzin: </gray><white><permission><br><gray>Diğer isimler: </gray><aliases>''><dark_aqua> ▪ <gray>/sonar <suggest-subcommand><subcommand></suggest-subcommand>  <white><description></hover></suggest-subcommand>'
+    subcommands: '<suggest-subcommand><hover:show_text:''<gray>Sadece oyuncular: </gray><only-players><br><gray>Konsol gerekli: </gray><only-console><br><gray>İzin: </gray><white><permission><br><gray>Diğer isimler: </gray><aliases>''><dark_aqua> ▪ <gray>/sonar <subcommand>  <white><description></hover></suggest-subcommand>'
     # Alt komutların üzerine gelinen metindeki evet (tick) ve hayır (cross) değerleri için biçimlendirme
     tick: '<green>✔</green>'
     cross: '<red>✗</red>'


### PR DESCRIPTION
The Turkish messages file wrapped the subcommand placeholder in a nested suggest-subcommand tag, unlike the other locales. This removes the nested tag so the rendered command line matches the rest of the translations.

Checked:
- .\gradlew.bat :common:processResources :common:spotlessCheck --console=plain

Note: .\gradlew.bat build currently fails at :captcha:test because Gradle discovers no tests in that module.