### PR TITLE
Fix message placeholder keys

### DIFF
--- a/common/src/main/resources/assets/messages/cs.yml
+++ b/common/src/main/resources/assets/messages/cs.yml
@@ -169,7 +169,7 @@ commands:
       - ' <dark_aqua>▪ <gray>Aktuální příchozí využitá šířka pásma: <white><incoming-traffic>'
       - ' <dark_aqua>▪ <gray>Aktuální odchozí využitá šířka pásma: <white><outgoing-traffic>'
       - ' <dark_aqua>▪ <gray>Celková příchozí využitá šířka pásma: <white><incoming-traffic-ttl>'
-      - ' <dark_aqua>▪ <gray>Celková odchozí využitá šířka pásma: <white><incoming-traffic-ttl>'
+      - ' <dark_aqua>▪ <gray>Celková odchozí využitá šířka pásma: <white><outgoing-traffic-ttl>'
 
   # Překlady pro '/sonar dump'
   dump:

--- a/common/src/main/resources/assets/messages/en.yml
+++ b/common/src/main/resources/assets/messages/en.yml
@@ -169,7 +169,7 @@ commands:
       - ' <dark_aqua>▪ <gray>Current incoming used bandwidth: <white><incoming-traffic>'
       - ' <dark_aqua>▪ <gray>Current outgoing used bandwidth: <white><outgoing-traffic>'
       - ' <dark_aqua>▪ <gray>Total incoming used bandwidth: <white><incoming-traffic-ttl>'
-      - ' <dark_aqua>▪ <gray>Total outgoing used bandwidth: <white><incoming-traffic-ttl>'
+      - ' <dark_aqua>▪ <gray>Total outgoing used bandwidth: <white><outgoing-traffic-ttl>'
 
   # Translations for '/sonar dump'
   dump:

--- a/common/src/main/resources/assets/messages/es.yml
+++ b/common/src/main/resources/assets/messages/es.yml
@@ -169,7 +169,7 @@ commands:
       - ' <dark_aqua>▪ <gray>Ancho de banda entrante utilizado actualmente: <white><incoming-traffic>'
       - ' <dark_aqua>▪ <gray>Ancho de banda utilizado saliente actual: <white><outgoing-traffic>'
       - ' <dark_aqua>▪ <gray>Ancho de banda entrante total utilizado: <white><incoming-traffic-ttl>'
-      - ' <dark_aqua>▪ <gray>Ancho de banda total utilizado saliente: <white><incoming-traffic-ttl>'
+      - ' <dark_aqua>▪ <gray>Ancho de banda total utilizado saliente: <white><outgoing-traffic-ttl>'
 
   # Translations for '/sonar dump'
   dump:

--- a/common/src/main/resources/assets/messages/fr.yml
+++ b/common/src/main/resources/assets/messages/fr.yml
@@ -88,9 +88,9 @@ commands:
     # Description de cette sous-commande
     description: "Activer ou désactiver les notifications d'attaque"
     # Message affiché lorsqu'un joueur s'abonne aux notifications d'attaque de Sonar
-    subscribed: "<prefix>Vous visualisez maintenant les notifications d'attaque de Sonar."
+    subscribe: "<prefix>Vous visualisez maintenant les notifications d'attaque de Sonar."
     # Message affiché lorsqu'un joueur se désabonne des notifications d'attaque de Sonar
-    unsubscribed: "<prefix>Vous ne visualisez plus les notifications d'attaque de Sonar."
+    unsubscribe: "<prefix>Vous ne visualisez plus les notifications d'attaque de Sonar."
 
   # Traductions pour '/sonar blacklist'
   blacklist:
@@ -107,7 +107,7 @@ commands:
     # Message affiché lorsque quelqu'un supprime une adresse IP de la liste noire
     remove: '<prefix>Adresse IP <ip> supprimée avec succès de la liste noire.'
     # Message affiché lorsque quelqu'un ajoute une adresse IP à la liste noire, mais qu'elle est déjà en liste noire
-    duplicate-ip: "<prefix>L'adresse IP que vous avez fournie est déjà sur la liste noire."
+    ip-duplicate: "<prefix>L'adresse IP que vous avez fournie est déjà sur la liste noire."
     # Message affiché lorsque quelqu'un supprime une adresse IP de la liste noire, mais qu'elle n'est pas en liste noire
     ip-not-found: "<prefix>L'adresse IP que vous avez fournie ne figure pas sur la liste noire."
 

--- a/common/src/main/resources/assets/messages/it.yml
+++ b/common/src/main/resources/assets/messages/it.yml
@@ -169,7 +169,7 @@ commands:
       - ' <dark_aqua>▪ <gray>Banda in ingresso attualmente utilizzata: <white><incoming-traffic>'
       - ' <dark_aqua>▪ <gray>Banda in uscita attualmente utilizzata: <white><outgoing-traffic>'
       - ' <dark_aqua>▪ <gray>Banda totale in ingresso utilizzata: <white><incoming-traffic-ttl>'
-      - ' <dark_aqua>▪ <gray>Banda totale in uscita utilizzata: <white><incoming-traffic-ttl>'
+      - ' <dark_aqua>▪ <gray>Banda totale in uscita utilizzata: <white><outgoing-traffic-ttl>'
 
   # Traduzioni per '/sonar dump'
   dump:

--- a/common/src/main/resources/assets/messages/ka.yml
+++ b/common/src/main/resources/assets/messages/ka.yml
@@ -35,7 +35,7 @@ commands:
   # მესიჯი, რომელიც იქნება ნაჩვენები, როდესაც მოთამაშე ცდის /sonar ს ამის უფლების გარეშე
   no-permission: '<prefix><red>თქვენ არ გაქვთ უფლება ამ ბრძანების გასაცემად.'
   # მესიჯი, რომელიც იქნება ნაჩვენები, როდესაც ბრძანება არასწორად იქნება გაცემული.
-  incorrect-გამოყენება: '<prefix><red>გამოყენება: /sonar <subcommand-გამოყენება>'
+  incorrect-usage: '<prefix><red>გამოყენება: /sonar <subcommand-usage>'
   # მესიჯი, რომელიც იქნება ნაჩვენები, როდესაც ვინმე გვაწვდის არასწორ IP მისამართს (არასწორი ფორმატით)
   invalid-ip-address: '<prefix>თქვენი IP მისამართი, როგორც ჩანს არასწორია.'
   # მესიჯი, რომელიც იქნება ნაჩვენები, როდესაც კონსოლი ცდის იმ ბრძანების გაცემას რომლის გაცემაც მხოლოდ მოთამაშეს შეუძლია.
@@ -56,7 +56,7 @@ commands:
       - <white><click:open_url:'https://sonar.top/discord/'><hover:show_text:'(დააჭირეთ რომ გახსნათ Discord)'>გახსენით ბილეთი Discord_ზე </hover></click><click:open_url:'https://github.com/jonesdevelopment/sonar/issues'><hover:show_text:'(დააჭირეთ რომ გახსნათ GitHub)'>ან შექმენით ახალი პრობლემის პოსტი GitHub_ზე.
       - ''
     # ქვე-ბრძანებების ფორმატი რომელიც არის ნაჩვენები მთავარი ბრძანების გაცემის დროს.
-    subcommands: '<suggest-subcommand><hover:show_text:''<gray>მხოლოდ მოთამაშეები: </gray><only-players><br><gray>აუცილებელია კონსოლი: </gray><only-console><br><gray>უფლება: </gray><white><permission><br><gray>სხვა-სახელი: </gray><aliases>''><dark_aqua> ▪ <gray>/sonar <ქვე-ბრძანება>  <white><description></hover></suggest-subcommand>'
+    subcommands: '<suggest-subcommand><hover:show_text:''<gray>მხოლოდ მოთამაშეები: </gray><only-players><br><gray>აუცილებელია კონსოლი: </gray><only-console><br><gray>უფლება: </gray><white><permission><br><gray>სხვა-სახელი: </gray><aliases>''><dark_aqua> ▪ <gray>/sonar <subcommand>  <white><description></hover></suggest-subcommand>'
     # ფორმატი კი_სთვის (სტიჩკა) და არა_სთვის (ჯვარი) (გამოიყენება ქვე-ბრძანებებში)
     tick: '<green>✔</green>'
     cross: '<red>✗</red>'
@@ -169,7 +169,7 @@ commands:
       - ' <dark_aqua>▪ <gray>ამჟამინდელი მომდინარე გამოყენებული ქსელის გამოყენება: <white><incoming-traffic>'
       - ' <dark_aqua>▪ <gray>ამჟამინდელი გამდინარე გამოყენებული ქსელის გამოყენება: <white><outgoing-traffic>'
       - ' <dark_aqua>▪ <gray>ჯამში მომდინარე გამოყენებული ქსელის გამოყენება: <white><incoming-traffic-ttl>'
-      - ' <dark_aqua>▪ <gray>ჯამში გამდინარე გამოყენებული ქსელის გამოყენება: <white><incoming-traffic-ttl>'
+      - ' <dark_aqua>▪ <gray>ჯამში გამდინარე გამოყენებული ქსელის გამოყენება: <white><outgoing-traffic-ttl>'
 
   # თარგმანი '/sonar dump' სთვის
   dump:

--- a/common/src/main/resources/assets/messages/pl.yml
+++ b/common/src/main/resources/assets/messages/pl.yml
@@ -172,7 +172,7 @@ commands:
       - ' <dark_aqua>▪ <gray>Aktualnie używana przychodząca przepustowość: <white><incoming-traffic>'
       - ' <dark_aqua>▪ <gray>Aktualnie używana przepustowość wychodząca: <white><outgoing-traffic>'
       - ' <dark_aqua>▪ <gray>Całkowita wykorzystana przepustowość przychodząca: <white><incoming-traffic-ttl>'
-      - ' <dark_aqua>▪ <gray>Całkowita wykorzystana przepustowość wychodząca: <white><incoming-traffic-ttl>'
+      - ' <dark_aqua>▪ <gray>Całkowita wykorzystana przepustowość wychodząca: <white><outgoing-traffic-ttl>'
 
   # Translations for '/sonar dump'
   dump:

--- a/common/src/main/resources/assets/messages/pt-br.yml
+++ b/common/src/main/resources/assets/messages/pt-br.yml
@@ -169,7 +169,7 @@ commands:
       - ' <dark_aqua>▪ <gray>Largura de banda usada atualmente (entrada): <white><incoming-traffic>'
       - ' <dark_aqua>▪ <gray>Largura de banda usada atualmente (saída): <white><outgoing-traffic>'
       - ' <dark_aqua>▪ <gray>Largura de banda total usada (entrada): <white><incoming-traffic-ttl>'
-      - ' <dark_aqua>▪ <gray>Largura de banda total usada (saída): <white><incoming-traffic-ttl>'
+      - ' <dark_aqua>▪ <gray>Largura de banda total usada (saída): <white><outgoing-traffic-ttl>'
 
   # Traduções para '/sonar dump'
   dump:

--- a/common/src/main/resources/assets/messages/tr.yml
+++ b/common/src/main/resources/assets/messages/tr.yml
@@ -138,7 +138,7 @@ commands:
     # Bu alt komut için açıklama
     description: "Bu sunucunun oturum istatistiklerini göster"
     # İstatistikleri görüntülerken her şeyin üzerinde gösterilen bilgilendirme mesajı
-    header: 'Bu oturum için <statistics-type> istatistikleri gösteriliyor:'
+    header: '<prefix>Bu oturum için <statistics-type> istatistikleri gösteriliyor:'
     # Message that is shown when a player tries viewing an unknown statistic
     unknown-type: '<prefix><red>Bilinmeyen istatistik türü! Mevcut istatistikler: <gray><statistics>'
     # Genel istatistik mesajının biçimi


### PR DESCRIPTION
Fix a few message keys/placeholders that drifted from the values used by the code.

Changed:
- French notify/blacklist keys
- Georgian command usage keys/placeholders
- Turkish statistics prefix placeholder
- total outgoing traffic placeholders in translated statistics messages