### PR TITLE
Release 2.1.49

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 group=xyz.jonesdev
-version=2.1.48
+version=2.1.49
 description=A lightweight, effective, and easy-to-use anti-bot plugin for Velocity, BungeeCord, and Bukkit.


### PR DESCRIPTION
This version introduces support for adventure 5 on Velocity and Paper. Moving forward, Sonar also requires Java 17 or higher.