### PR TITLE
Release 2.1.50

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 group=xyz.jonesdev
-version=2.1.49
+version=2.1.50
 description=A lightweight, effective, and easy-to-use anti-bot plugin for Velocity, BungeeCord, and Bukkit.


### PR DESCRIPTION
This is a hotfix release that reintroduces support for adventure 4.x servers. Paper 26.x servers are now supported.