### PR TITLE
Prevent TailExceptionsHandler from racing a graceful closeWith() close

### DIFF
--- a/common/src/main/java/xyz/jonesdev/sonar/common/netty/TailExceptionsHandler.java
+++ b/common/src/main/java/xyz/jonesdev/sonar/common/netty/TailExceptionsHandler.java
@@ -21,6 +21,7 @@ import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.ChannelHandlerContext;
 import org.jetbrains.annotations.NotNull;
+import xyz.jonesdev.sonar.common.util.ProtocolUtil;
 
 @ChannelHandler.Sharable
 public final class TailExceptionsHandler extends ChannelDuplexHandler {
@@ -33,6 +34,20 @@ public final class TailExceptionsHandler extends ChannelDuplexHandler {
   // Additionally, this will also run after our custom decoder.
   @Override
   public void exceptionCaught(final @NotNull ChannelHandlerContext ctx, final Throwable cause) throws Exception {
+    // If ProtocolUtil#closeWith(...) already queued a graceful write-then-close for
+    // this channel (e.g. VerificationHandler#fail() calls disconnect() and then
+    // throws to unwind), don't race it with a second, immediate close() here. Doing
+    // so can abort the still-in-flight kick/disconnect packet write before it's fully
+    // flushed, so the client only receives a truncated packet instead of our message.
+    // The scheduled close from closeWith() will still run once the write completes.
+    // See: https://github.com/jonesdevelopment/sonar/issues/476
+    if (Boolean.TRUE.equals(ctx.channel().attr(ProtocolUtil.CLOSING).get())) {
+      if (LOG_EXCEPTIONS) {
+        cause.printStackTrace(System.err);
+      }
+      return;
+    }
+
     // Close the channel if we encounter any errors.
     ctx.close();
     if (LOG_EXCEPTIONS) {

--- a/common/src/main/java/xyz/jonesdev/sonar/common/util/ProtocolUtil.java
+++ b/common/src/main/java/xyz/jonesdev/sonar/common/util/ProtocolUtil.java
@@ -24,6 +24,7 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.handler.codec.DecoderException;
 import io.netty.handler.codec.EncoderException;
+import io.netty.util.AttributeKey;
 import io.netty.util.Version;
 import lombok.experimental.UtilityClass;
 import net.kyori.adventure.nbt.BinaryTag;
@@ -217,9 +218,20 @@ public class ProtocolUtil {
     }
   }
 
+  public static final AttributeKey<Boolean> CLOSING = AttributeKey.valueOf("sonar-graceful-close-in-progress");
+
   public static void closeWith(final @NotNull Channel channel,
                                final @NotNull ProtocolVersion protocolVersion,
                                final @NotNull Object msg) {
+    // Mark this channel as already undergoing a graceful close *before* we queue the
+    // write. If something downstream (e.g. an exception thrown right after this call,
+    // such as VerificationHandler#fail()'s QuietDecoderException) reaches
+    // TailExceptionsHandler while our writeAndFlush(...).addListener(CLOSE) is still
+    // in flight, that handler must not call ctx.close() a second time - doing so can
+    // abort the still-pending write and deliver only a truncated packet to the client
+    // (which then sees a bare disconnect/reset instead of our kick message).
+    // See: https://github.com/jonesdevelopment/sonar/issues/476
+    channel.attr(CLOSING).set(true);
     if (protocolVersion.lessThan(ProtocolVersion.MINECRAFT_1_8)) {
       channel.eventLoop().execute(() -> {
         channel.config().setAutoRead(false);


### PR DESCRIPTION
## How do I reproduce this?
Hard to reproduce reliably against a live server/client - it depends on the kick packet's write not completing synchronously, which is more likely under load (many concurrent connections, e.g. via SoulFire bot floods, per https://github.com/jonesdevelopment/sonar/issues/476). Instead, I isolated the exact mechanism with a standalone repro on plain sockets (no Netty/Sonar dependencies needed): RaceTest.java (attached). It simulates an async write-then-close racing against an immediate, independent second close() call while the write is still in flight - the same pattern as VerificationHandler#fail() calling disconnect() and then throwing.

Every run: the write fails with `SocketException: Socket closed`, and the client receives only a truncated fragment of the payload instead of the full message - reproducing the "client gets a bare reset instead of the kick message" symptom from https://github.com/jonesdevelopment/sonar/issues/476.

I also tested and ruled out the alternative theory that this is caused by a TCP RST from unread data in the receive buffer at close() time (RstTest.java, attached) - that does not reproduce here even with 2MB of unread data, with a SO_LINGER(0) sanity control confirming the harness can detect RST when it actually occurs.

## Root cause
`VerificationHandler#fail()` calls `user.disconnect(...)`, which queues an async `channel.writeAndFlush(msg).addListener(ChannelFutureListener.CLOSE)` in `ProtocolUtil#closeWith()`, and then immediately throws `QuietDecoderException.INSTANCE` to unwind. That exception propagates through `SonarPacketDecoder#channelRead()` and reaches `TailExceptionsHandler#exceptionCaught()`, which calls `ctx.close()` unconditionally - a second, independent close racing the one already queued. If the kick packet write hasn't finished flushing yet, this second close aborts it, so the client only gets a truncated packet instead of the full kick message.

https://github.com/jonesdevelopment/sonar/pull/595 attempted to fix this by catching `QuietDecoderException` in the decoder, but `QuietDecoderException.INSTANCE` is also thrown from ~15 other places (`MinecraftVarInt21FrameDecoder`, `LoginStartPacket`, `SystemChatPacket`, `PluginMessagePacket`, etc.) that never call `disconnect()` first and rely entirely on reaching `TailExceptionsHandler` to close the connection at all. Catching it in the decoder would silently leave those connections open indefinitely - a resource leak / DoS surface for an antibot plugin.

## Fix
Tag the channel with a `CLOSING` attribute right when `closeWith()` queues its write, and have `TailExceptionsHandler` skip its own `close()` only when that attribute is set - every other `QuietDecoderException` throw site keeps closing the connection exactly as before.

## Verification
Reproduced the race directly with RaceTest.java (attached, 5/5 runs). Have not been able to verify against a live server + SoulFire per the repro steps in https://github.com/jonesdevelopment/sonar/issues/476 - would appreciate a maintainer or the original reporter confirming against a real setup.

## References
* Fixes https://github.com/jonesdevelopment/sonar/issues/476
* Related to https://github.com/jonesdevelopment/sonar/pull/595 (supersedes its decoder-level approach; see Root cause)
* [RaceTest.java](https://github.com/user-attachments/files/30265228/RaceTest.java)
* [RstTest.java](https://github.com/user-attachments/files/30265230/RstTest.java)