### PR TITLE
Release 2.1.51

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
 group=xyz.jonesdev
-version=2.1.50
+version=2.1.51
 description=A lightweight, effective, and easy-to-use anti-bot plugin for Velocity, BungeeCord, and Bukkit.


### PR DESCRIPTION
This update fixes an issue where 26.2 players receive a pink dye instead of the filled map item during the captcha. In addition, graceful disconnecting now prevents "Connection reset" kicks.

**Full Changelog**
- Prevent TailExceptionsHandler from racing a graceful close [#616](<https://github.com/jonesdevelopment/sonar/pull/616>)
- Fix `filled_map` item type ID on 26.2
- Implement missing check for blacklist scores of 0
- Bump various dependencies